### PR TITLE
Admins can view the list of partners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/ "The Keep a Changelog website")
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html "Semantic Versioning 2.0.0 specification").
+
+## [Unreleased]
+### Added
+- One can view the list of partners.

--- a/app/Http/Controllers/Admin/PartnersController.php
+++ b/app/Http/Controllers/Admin/PartnersController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Partner;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+/**
+ * Handles actions targeting the partners of the currency.
+ */
+class PartnersController extends Controller
+{
+    /**
+     * Display a list of partners.
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function index()
+    {
+        $partners = Partner::all();
+
+        return view('admin.partners.index', compact('partners'));
+    }
+}

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A Partner is a person or organization that uses the local currency.
+ */
+class Partner extends Model
+{
+    //
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -13,7 +14,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        // Set the default string length for database migrations.
+        // @see https://laravel.com/docs/5.4/migrations#indexes
+        Schema::defaultStringLength(191);
     }
 
     /**

--- a/database/factories/Partner.php
+++ b/database/factories/Partner.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Partner;
+use Faker\Generator as Faker;
+
+// Factory to create a basic Partner model.
+$factory->define(Partner::class, function (Faker $faker) {
+    return [
+        'name' => $faker->company,
+    ];
+});

--- a/database/migrations/2017_07_15_215105_create_partners_table.php
+++ b/database/migrations/2017_07_15_215105_create_partners_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePartnersTable extends Migration
+{
+    /**
+     * Create the table of partners.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('partners', function (Blueprint $table) {
+
+            // Primary key.
+            // An unsigned integer with autoincrement.
+            $table->increments('id');
+
+            // The name of the partner.
+            $table->string('name');
+
+            // Timestamps telling when the table row was created
+            // and when it was modified for the last time.
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Drop the table of partners.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('partners');
+    }
+}

--- a/resources/views/admin/base-layout.blade.php
+++ b/resources/views/admin/base-layout.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>@yield('title')</title>
+</head>
+<body>
+    <main>
+        @yield('content')
+    </main>
+</body>
+</html>

--- a/resources/views/admin/partners/index.blade.php
+++ b/resources/views/admin/partners/index.blade.php
@@ -1,0 +1,11 @@
+@extends('admin.base-layout')
+
+@section('title', 'Liste des partenaires prestataires')
+
+@section('content')
+    <ul>
+        @foreach ($partners as $partner)
+            <li>{{ $partner->name }}</li>
+        @endforeach
+    </ul>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,4 +3,9 @@
 // This group defines the routes used by the administration area of the site.
 Route::prefix('gestion')->namespace('Admin')->group(function () {
 
+    // Define routes to handle partners of the local currency.
+    Route::resource('partners', 'PartnersController', [
+        'only' => ['index']
+    ]);
+
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,2 +1,6 @@
 <?php
 
+// This group defines the routes used by the administration area of the site.
+Route::prefix('gestion')->namespace('Admin')->group(function () {
+
+});

--- a/tests/Feature/Admin/ViewPartnersList.php
+++ b/tests/Feature/Admin/ViewPartnersList.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Partner;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ViewPartnersList extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function admins_can_see_the_list_of_partners()
+    {
+        // Create three partners.
+        $partnerA = factory(Partner::class)->create(['name' => 'Boucherie Sanzot']);
+        $partnerB = factory(Partner::class)->create(['name' => 'Du côté de chez Poje']);
+        $partnerC = factory(Partner::class)->create(['name' => 'Poissonnerie Ordralfabétix']);
+
+        $response = $this->get('/gestion/partners');
+
+        // Check if the created partners are listed on the page.
+        $response->assertSeeText($partnerA->name);
+        $response->assertSeeText($partnerB->name);
+        $response->assertSeeText($partnerC->name);
+    }
+}


### PR DESCRIPTION
This is a very very minimal implementation that provides a single page (available at `/gestion/partners`) that simply lists the names of all the partners of the currency.

It is mostly useful because it provides the base infrastructure that is required to make this work. As a result, future work will be able to build upon these foundations in order to improve the feature.