### PR TITLE
Admins can view the details of a specific partner

### DIFF
--- a/app/Http/Controllers/Admin/PartnersController.php
+++ b/app/Http/Controllers/Admin/PartnersController.php
@@ -22,4 +22,16 @@ class PartnersController extends Controller
 
         return view('admin.partners.index', compact('partners'));
     }
+
+    /**
+     * Display a single partner.
+     *
+     * @param  \App\Partner  $partner  The partner that will be displayed
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function show(Partner $partner)
+    {
+        return view('admin.partners.show', compact('partner'));
+    }
 }

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -25,4 +25,20 @@ class Partner extends Model
             $partner->slug = Str::slug($partner->name);
         });
     }
+
+    /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName()
+    {
+        // Every time a route explicitly or implicitly expects a partner
+        // in one of its segments, it will look for this partner by
+        // using its slug instead of the usual primary key.
+        //
+        // This means that if there is a route like 'foo/{partner}', the
+        // partner placeholder will be filled with the slug, not the ID.
+        return 'slug';
+    }
 }

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -22,7 +22,9 @@ class Partner extends Model
         // When a partner is created, we automatically
         // generate a slug based on its name.
         self::creating(function (self $partner) {
-            $partner->slug = Str::slug($partner->name);
+            if (is_null($partner->slug)) {
+                $partner->slug = Str::slug($partner->name);
+            }
         });
     }
 

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -9,5 +10,19 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Partner extends Model
 {
-    //
+    /**
+     * The "booting" method of the model.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        // When a partner is created, we automatically
+        // generate a slug based on its name.
+        self::creating(function (self $partner) {
+            $partner->slug = Str::slug($partner->name);
+        });
+    }
 }

--- a/database/migrations/2017_07_15_215105_create_partners_table.php
+++ b/database/migrations/2017_07_15_215105_create_partners_table.php
@@ -22,6 +22,20 @@ class CreatePartnersTable extends Migration
             // The name of the partner.
             $table->string('name');
 
+            // The name of the partner, but maybe in a modified form that will
+            // make it easier for people to find it in an alphabetical list.
+            // Example : 'Du côté de chez Poje' → 'Poje (du côté de chez)'
+            $table->string('name_sort')->nullable();
+
+            // The slug is a simplified version of the name that is
+            // both people-friendly and computer-friendly, for use
+            // in places such as URLs or filenames.
+            $table->string('slug');
+
+            // The type of business (ASBL, SPRL, indépendant en
+            // personne physique, etc.)
+            $table->string('business_type')->nullable();
+
             // Timestamps telling when the table row was created
             // and when it was modified for the last time.
             $table->timestamps();

--- a/resources/views/admin/partners/show.blade.php
+++ b/resources/views/admin/partners/show.blade.php
@@ -1,0 +1,10 @@
+@extends('admin.base-layout')
+
+@section('title', $partner->name)
+
+@section('content')
+    <h1>{{ $partner->name }}</h1>
+
+    <p>Nom de liste : <strong>{{ $partner->name_sort or '---' }}</strong></p>
+    <p>Forme juridique : <strong>{{ $partner->business_type or 'inconnue' }}</strong></p>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,7 @@ Route::prefix('gestion')->namespace('Admin')->group(function () {
 
     // Define routes to handle partners of the local currency.
     Route::resource('partners', 'PartnersController', [
-        'only' => ['index']
+        'only' => ['index', 'show']
     ]);
 
 });

--- a/tests/Feature/Admin/ViewDetailsOfAPartnerTest.php
+++ b/tests/Feature/Admin/ViewDetailsOfAPartnerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Partner;
+use Tests\TestCase;
+use Illuminate\Support\Str;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ViewDetailsOfAPartnerTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function admins_can_see_a_particular_partner()
+    {
+        // Create two partners.
+        $partner = factory(Partner::class)->create([
+            'name' => 'Du côté de chez Poje',
+            'name_sort' => 'Poje (du côté de chez)',
+            'business_type' => 'SPRL',
+        ]);
+        $otherPartner = factory(Partner::class)->create([
+            'name' => 'Boucherie Sanzot',
+        ]);
+
+        $response = $this->get('/gestion/partners/'.$partner->slug);
+
+        // Check that we can see the details of a specific partner.
+        $response->assertSeeText($partner->name);
+        $response->assertSeeText($partner->name_sort);
+        $response->assertSeeText($partner->business_type);
+
+        // Check that we don’t see anything related to the other partner.
+        $response->assertDontSeeText($otherPartner->name);
+    }
+}

--- a/tests/Feature/Admin/ViewPartnersListTest.php
+++ b/tests/Feature/Admin/ViewPartnersListTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
-class ViewPartnersList extends TestCase
+class ViewPartnersListTest extends TestCase
 {
     use DatabaseMigrations;
 

--- a/tests/Unit/PartnerTest.php
+++ b/tests/Unit/PartnerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Admin;
+
+use App\Partner;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class PartnerTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function can_generate_a_slug_from_the_name_when_creating_a_partner()
+    {
+        // Create a partner.
+        $partner = factory(Partner::class)->create([
+            'name' => 'Boucherie Sanzot',
+            // Ensure there is no defined slug before creating the model.
+            'slug' => null,
+        ]);
+
+        // Check that a slug has been properly generated.
+        $this->assertSame('boucherie-sanzot', $partner->slug);
+    }
+}

--- a/tests/Unit/PartnerTest.php
+++ b/tests/Unit/PartnerTest.php
@@ -25,4 +25,20 @@ class PartnerTest extends TestCase
         // Check that a slug has been properly generated.
         $this->assertSame('boucherie-sanzot', $partner->slug);
     }
+
+    /** @test */
+    public function do_not_automatically_generate_a_slug_if_one_is_already_defined()
+    {
+        // Create a partner.
+        $partner = factory(Partner::class)->create([
+            'name' => 'Boucherie Sanzot',
+            // Ensure there IS a defined slug before creating the model.
+            'slug' => 'my-special-slug',
+        ]);
+
+        // Check that the slug we provided has been kept as is,
+        // that it had not been overwitten by a new one.
+        $this->assertSame('my-special-slug', $partner->slug);
+        $this->assertNotSame('boucherie-sanzot', $partner->slug);
+    }
 }


### PR DESCRIPTION
This is a very minimal implementation that provides a single page (available at `/gestion/partners/{slug}`) that simply shows some details of a specific partner.

This pull request also brings the ability for `Partner` models to automatically generate their slug from their name if no slug is defined at creation time.

Finally, it adds the `name_sort`, `slug` and `business_type` columns to the table of partners and, as a result, to the models themselves.