### PR TITLE
Partners can have associated locations

### DIFF
--- a/app/Location.php
+++ b/app/Location.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A location is a place where a partner welcomes its customers. For example, it
+ * may be a shop, a restaurant, an office or any other place were the currency
+ * will be used and exchanged between the partner and its customers.
+ */
+class Location extends Model
+{
+    /**
+     * Get the partner that owns the location.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function partner()
+    {
+        return $this->belongsTo(Partner::class);
+    }
+}

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -43,4 +43,14 @@ class Partner extends Model
         // partner placeholder will be filled with the slug, not the ID.
         return 'slug';
     }
+
+    /**
+     * Get the locations of the partner.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function locations()
+    {
+        return $this->hasMany(Location::class);
+    }
 }

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * A Partner is a person or organization that uses the local currency.
+ * A partner is a person or organization that uses the local currency.
  */
 class Partner extends Model
 {

--- a/database/factories/Location.php
+++ b/database/factories/Location.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Location;
+use Faker\Generator as Faker;
+
+// Factory to create a basic Location model.
+$factory->define(Location::class, function (Faker $faker) {
+    return [
+        'name' => "{$faker->company} {$faker->city}",
+    ];
+});

--- a/database/migrations/2017_07_29_132203_CreateLocationsTable.php
+++ b/database/migrations/2017_07_29_132203_CreateLocationsTable.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateLocationsTable extends Migration
+{
+    /**
+     * Create the table of locations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('locations', function (Blueprint $table) {
+
+            // Primary key.
+            // An unsigned integer with autoincrement.
+            $table->increments('id');
+
+            // Foreign key.
+            // This references the partner owning the location.
+            $table->unsignedInteger('partner_id');
+            $table->foreign('partner_id')->references('id')->on('partners');
+
+            // A name for the location.
+            $table->string('name');
+
+            // Timestamps telling when the table row was created
+            // and when it was modified for the last time.
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Drop the table of locations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('locations');
+    }
+}

--- a/tests/Unit/LocationTest.php
+++ b/tests/Unit/LocationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Admin;
+
+use App\Partner;
+use App\Location;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class LocationTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    function can_retrieve_its_partner()
+    {
+        $partner = factory(Partner::class)->create();
+
+        $location = factory(Location::class)->create([
+            'partner_id' => $partner->id,
+        ]);
+
+        $retrievedPartner = $location->partner;
+
+        $this->assertSame($partner->id, $retrievedPartner->id);
+    }
+}

--- a/tests/Unit/PartnerTest.php
+++ b/tests/Unit/PartnerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Admin;
 
 use App\Partner;
+use App\Location;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -40,5 +41,36 @@ class PartnerTest extends TestCase
         // that it had not been overwitten by a new one.
         $this->assertSame('my-special-slug', $partner->slug);
         $this->assertNotSame('boucherie-sanzot', $partner->slug);
+    }
+
+    /** @test */
+    function can_retrieve_its_locations()
+    {
+        // Create a partner.
+        $partner = factory(Partner::class)->create([
+            'name' => 'Boucherie Sanzot',
+        ]);
+
+        // Then, create two locations for this partner.
+        $location1 = factory(Location::class)->create([
+            'name' => 'Magasin rue du Nord',
+            'partner_id' => $partner->id,
+        ]);
+        $location2 = factory(Location::class)->create([
+            'name' => 'Magasin rue du Sud',
+            'partner_id' => $partner->id,
+        ]);
+
+        // Retrieve the locations.
+        $locations = $partner->locations;
+
+        // Check that we got the correct locations.
+        $this->assertCount(2, $locations);
+
+        $this->assertSame($location1->id, $locations[0]->id);
+        $this->assertSame('Magasin rue du Nord', $locations[0]->name);
+
+        $this->assertSame($location2->id, $locations[1]->id);
+        $this->assertSame('Magasin rue du Sud', $locations[1]->name);
     }
 }


### PR DESCRIPTION
This pull request brings the concept of locations — places where the currency is used and exchanged between a partner and its customers.

Each partner can have one or more locations, and each location always belongs to just a single partner.