### PR TITLE
Partners can have representatives

### DIFF
--- a/app/Partner.php
+++ b/app/Partner.php
@@ -53,4 +53,14 @@ class Partner extends Model
     {
         return $this->hasMany(Location::class);
     }
+
+    /**
+     * Get the person(s) who represent the partner.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function representatives()
+    {
+        return $this->hasMany(PartnerRepresentative::class);
+    }
 }

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use DomainException;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,29 @@ use Illuminate\Database\Eloquent\Model;
  */
 class PartnerRepresentative extends Model
 {
+    /**
+     * The "booting" method of the model.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        // When a representative is created, if an e-mail address has
+        // been provided, we check that it has a valid syntax.
+        self::creating(function (self $representative) {
+            if (
+                $representative->hasEmail() &&
+                filter_var($representative->email, FILTER_VALIDATE_EMAIL) === false
+            ) {
+                throw new DomainException(
+                    "[{$representative->email}] is an invalid e-mail address"
+                );
+            }
+        });
+    }
+
     /**
      * Get the partner that this person represents.
      *

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -13,26 +13,18 @@ use Illuminate\Database\Eloquent\Model;
 class PartnerRepresentative extends Model
 {
     /**
-     * The "booting" method of the model.
+     * Set the partner representative’s email.
      *
+     * @param  string  $email
      * @return void
      */
-    protected static function boot()
+    public function setEmailAttribute($email)
     {
-        parent::boot();
+        if (!is_null($email) && filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            throw new DomainException("[{$email}] is an invalid e-mail address.");
+        }
 
-        // When a representative is created, if an e-mail address has
-        // been provided, we check that it has a valid syntax.
-        self::creating(function (self $representative) {
-            if (
-                $representative->hasEmail() &&
-                filter_var($representative->email, FILTER_VALIDATE_EMAIL) === false
-            ) {
-                throw new DomainException(
-                    "[{$representative->email}] is an invalid e-mail address"
-                );
-            }
-        });
+        $this->attributes['email'] = $email;
     }
 
     /**

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -36,6 +36,30 @@ class PartnerRepresentative extends Model
     }
 
     /**
+     * Set the partner representative’s phone number.
+     *
+     * @param  string  $phone
+     * @return void
+     */
+    public function setPhoneAttribute($phone)
+    {
+        // If a phone number has been provided, we check if it is valid.
+        // If it is, we then format it in the E.164 format.
+        // @see https://en.wikipedia.org/wiki/E.164
+        if (!is_null($phone)) {
+
+            if (validator([$phone], ['phone:BE'])->fails()) {
+                throw new DomainException("[{$phone}] is an invalid phone number.");
+            }
+
+            // The number seems valid. Format it in a standard way.
+            $phone = phone($phone, 'BE')->formatE164();
+        }
+
+        $this->attributes['phone'] = $phone;
+    }
+
+    /**
      * Get the partner that this person represents.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -54,4 +54,14 @@ class PartnerRepresentative extends Model
     {
         return !is_null($this->email);
     }
+
+    /**
+     * Check if the representative has a phone number.
+     *
+     * @return bool
+     */
+    public function hasPhone()
+    {
+        return !is_null($this->phone);
+    }
 }

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A representative is a person who is officially acting in the name of a
+ * partner. This person is the one who communicates with the organization
+ * managing the currency project.
+ */
+class PartnerRepresentative extends Model
+{
+    /**
+     * Get the partner that this person represents.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function partner()
+    {
+        return $this->belongsTo(Partner::class);
+    }
+}

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -20,4 +20,14 @@ class PartnerRepresentative extends Model
     {
         return $this->belongsTo(Partner::class);
     }
+
+    /**
+     * Check if the representative has an e-mail address.
+     *
+     * @return bool
+     */
+    public function hasEmail()
+    {
+        return !is_null($this->email);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=5.6.4",
         "laravel/framework": "5.4.*",
-        "laravel/tinker": "~1.0"
+        "laravel/tinker": "~1.0",
+        "propaganistas/laravel-phone": "^3.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "84190fed6c3345e6904b2fe9b932e352",
+    "content-hash": "ba0c41a7f74d41d8aec98095a60fc9c1",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -149,6 +149,123 @@
             "time": "2017-05-14T14:47:48+00:00"
         },
         {
+            "name": "giggsey/libphonenumber-for-php",
+            "version": "8.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/libphonenumber-for-php.git",
+                "reference": "dd9cf2a10a8671d3934a7a315e927df46548bcc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/dd9cf2a10a8671d3934a7a315e927df46548bcc9",
+                "reference": "dd9cf2a10a8671d3934a7a315e927df46548bcc9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "giggsey/locale": "^1.2",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "pear/pear-core-minimal": "^1.9",
+                "pear/pear_exception": "^1.0",
+                "pear/versioncontrol_git": "dev-master",
+                "phing/phing": "^2.7",
+                "phpunit/phpunit": "^4.8|^5.0",
+                "satooshi/php-coveralls": "^1.0",
+                "symfony/console": "^2.8|^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "libphonenumber\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "/src/data/",
+                    "/src/carrier/data/",
+                    "/src/geocoding/data/",
+                    "/src/timezone/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "PHP Port of Google's libphonenumber",
+            "homepage": "https://github.com/giggsey/libphonenumber-for-php",
+            "keywords": [
+                "geocoding",
+                "geolocation",
+                "libphonenumber",
+                "mobile",
+                "phonenumber",
+                "validation"
+            ],
+            "time": "2017-07-18T13:07:45+00:00"
+        },
+        {
+            "name": "giggsey/locale",
+            "version": "1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/Locale.git",
+                "reference": "e6eb1883c1452df7734a03fb183a2ec5175c16f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/e6eb1883c1452df7734a03fb183a2ec5175c16f2",
+                "reference": "e6eb1883c1452df7734a03fb183a2ec5175c16f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "pear/pear-core-minimal": "^1.9",
+                "pear/pear_exception": "^1.0",
+                "pear/versioncontrol_git": "dev-master",
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "^4.8|^5.0",
+                "satooshi/php-coveralls": "^1.0",
+                "symfony/console": "^2.8|^3.0",
+                "symfony/filesystem": "^2.8|^3.0",
+                "symfony/finder": "^2.8|^3.0",
+                "symfony/process": "^2.8|^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Giggsey\\Locale\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "http://giggsey.com/"
+                }
+            ],
+            "description": "Locale functions required by libphonenumber-for-php",
+            "time": "2017-04-07T18:45:42+00:00"
+        },
+        {
             "name": "jakub-onderka/php-console-color",
             "version": "0.1",
             "source": {
@@ -234,6 +351,39 @@
                 }
             ],
             "time": "2015-04-20T18:58:01+00:00"
+        },
+        {
+            "name": "julien-c/iso3166",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/julien-c/iso3166.git",
+                "reference": "d7bd56333a1ed901fbc41d5a5c92d88a2a6cb88c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/julien-c/iso3166/zipball/d7bd56333a1ed901fbc41d5a5c92d88a2a6cb88c",
+                "reference": "d7bd56333a1ed901fbc41d5a5c92d88a2a6cb88c",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Iso3166\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Julien Chaumond",
+                    "email": "chaumond@gmail.com"
+                }
+            ],
+            "description": "ISO 3166-1 alpha-2 mapping",
+            "time": "2015-12-15T15:40:03+00:00"
         },
         {
             "name": "laravel/framework",
@@ -783,6 +933,70 @@
                 "random"
             ],
             "time": "2017-03-13T16:27:32+00:00"
+        },
+        {
+            "name": "propaganistas/laravel-phone",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Propaganistas/Laravel-Phone.git",
+                "reference": "48584eda0f5275f7d35e7ce15f26951b9a34b545"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Propaganistas/Laravel-Phone/zipball/48584eda0f5275f7d35e7ce15f26951b9a34b545",
+                "reference": "48584eda0f5275f7d35e7ce15f26951b9a34b545",
+                "shasum": ""
+            },
+            "require": {
+                "giggsey/libphonenumber-for-php": "^7.0|^8.0",
+                "illuminate/support": "^5.0",
+                "illuminate/validation": "^5.0",
+                "julien-c/iso3166": "^2.0",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "orchestra/testbench": "*",
+                "phpunit/phpunit": "^4.0|^5.0"
+            },
+            "suggest": {
+                "propaganistas/laravel-intl": "Adds internationalization functions, including a compatible and fully translated country list API."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Propaganistas\\LaravelPhone\\PhoneServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Propaganistas\\LaravelPhone\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Propaganistas",
+                    "email": "Propaganistas@users.noreply.github.com"
+                }
+            ],
+            "description": "Adds phone number functionality to Laravel and Lumen based on Google's libphonenumber API.",
+            "keywords": [
+                "laravel",
+                "libphonenumber",
+                "lumen",
+                "phone",
+                "validation"
+            ],
+            "time": "2017-07-25T18:22:59+00:00"
         },
         {
             "name": "psr/log",

--- a/config/app.php
+++ b/config/app.php
@@ -167,6 +167,7 @@ return [
          * Package Service Providers...
          */
         Laravel\Tinker\TinkerServiceProvider::class,
+        Propaganistas\LaravelPhone\PhoneServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/database/factories/PartnerRepresentative.php
+++ b/database/factories/PartnerRepresentative.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\PartnerRepresentative;
+use Faker\Generator as Faker;
+
+// Factory to create a basic PartnerRepresentative model.
+$factory->define(PartnerRepresentative::class, function (Faker $faker) {
+    return [
+        'partner_id' => $faker->randomDigitNotNull(),
+        'given_name' => $faker->firstName,
+        'surname' => $faker->lastName,
+        'role' => 'responsable',
+    ];
+});

--- a/database/migrations/2017_07_30_182220_create_partner_representatives_table.php
+++ b/database/migrations/2017_07_30_182220_create_partner_representatives_table.php
@@ -30,6 +30,9 @@ class CreatePartnerRepresentativesTable extends Migration
             // The role or position that the person fills for the partner.
             $table->string('role');
 
+            // An optional e-mail address the person may be contacted at.
+            $table->string('email')->nullable();
+
             // Timestamps telling when the table row was created
             // and when it was modified for the last time.
             $table->timestamps();

--- a/database/migrations/2017_07_30_182220_create_partner_representatives_table.php
+++ b/database/migrations/2017_07_30_182220_create_partner_representatives_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePartnerRepresentativesTable extends Migration
+{
+    /**
+     * Create the table of partners.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('partner_representatives', function (Blueprint $table) {
+
+            // Primary key.
+            // An unsigned integer with autoincrement.
+            $table->increments('id');
+
+            // Foreign key.
+            // This references the partner represented by the person.
+            $table->unsignedInteger('partner_id');
+            $table->foreign('partner_id')->references('id')->on('partners');
+
+            $table->string('given_name');
+            $table->string('surname');
+
+            // The role or position that the person fills for the partner.
+            $table->string('role');
+
+            // Timestamps telling when the table row was created
+            // and when it was modified for the last time.
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Drop the table of partners.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('partners');
+    }
+}

--- a/database/migrations/2017_07_30_182220_create_partner_representatives_table.php
+++ b/database/migrations/2017_07_30_182220_create_partner_representatives_table.php
@@ -33,6 +33,9 @@ class CreatePartnerRepresentativesTable extends Migration
             // An optional e-mail address the person may be contacted at.
             $table->string('email')->nullable();
 
+            // An optional phone number, in international format.
+            $table->string('phone')->nullable();
+
             // Timestamps telling when the table row was created
             // and when it was modified for the last time.
             $table->timestamps();

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -51,4 +51,18 @@ class PartnerRepresentativeTest extends TestCase
             'email' => 'invalid-email-address',
         ]);
     }
+
+    /** @test */
+    function can_have_an_optional_phone_number()
+    {
+        $representativeA = factory(PartnerRepresentative::class)->make([
+            'phone' => '+32489123456',
+        ]);
+        $representativeB = factory(PartnerRepresentative::class)->make([
+            'phone' => null,
+        ]);
+
+        $this->assertTrue($representativeA->hasPhone());
+        $this->assertFalse($representativeB->hasPhone());
+    }
 }

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -40,4 +40,15 @@ class PartnerRepresentativeTest extends TestCase
         $this->assertTrue($representativeA->hasEmail());
         $this->assertFalse($representativeB->hasEmail());
     }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function the_email_address_must_be_valid()
+    {
+        $representative = factory(PartnerRepresentative::class)->create([
+            'email' => 'invalid-email-address',
+        ]);
+    }
 }

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Admin;
+
+use App\Partner;
+use Tests\TestCase;
+use App\PartnerRepresentative;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class PartnerRepresentativeTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    function can_retrieve_its_partner()
+    {
+        $partner = factory(Partner::class)->create();
+
+        $representative = factory(PartnerRepresentative::class)->create([
+            'partner_id' => $partner->id,
+        ]);
+
+        $retrievedPartner = $representative->partner;
+
+        $this->assertSame($partner->id, $retrievedPartner->id);
+    }
+}

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -65,4 +65,37 @@ class PartnerRepresentativeTest extends TestCase
         $this->assertTrue($representativeA->hasPhone());
         $this->assertFalse($representativeB->hasPhone());
     }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function the_phone_number_must_be_valid()
+    {
+        factory(PartnerRepresentative::class)->make(['phone' => '12345']);
+    }
+
+    /** @test */
+    function the_phone_number_can_be_provided_in_multiple_formats()
+    {
+        // International format (E.164).
+        factory(PartnerRepresentative::class)->make(['phone' => '+32489123456']);
+
+        // National format, without spaces.
+        factory(PartnerRepresentative::class)->make(['phone' => '0489123456']);
+
+        // National format, with spaces.
+        factory(PartnerRepresentative::class)->make(['phone' => '0489 12 34 56']);
+        factory(PartnerRepresentative::class)->make(['phone' => '0489 123 456']);
+
+        // Without leading zero.
+        factory(PartnerRepresentative::class)->make(['phone' => '489 123 456']);
+        factory(PartnerRepresentative::class)->make(['phone' => '489 123 456']);
+
+        // With slash and dots.
+        factory(PartnerRepresentative::class)->make(['phone' => '0489/12.34.56']);
+
+        // Totally drunk…
+        factory(PartnerRepresentative::class)->make(['phone' => '+32 (0) 48 9 123 4 56']);
+    }
 }

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -26,4 +26,18 @@ class PartnerRepresentativeTest extends TestCase
 
         $this->assertSame($partner->id, $retrievedPartner->id);
     }
+
+    /** @test */
+    function can_have_an_optional_email_address()
+    {
+        $representativeA = factory(PartnerRepresentative::class)->create([
+            'email' => 'henri@boucheriesanzot.be',
+        ]);
+        $representativeB = factory(PartnerRepresentative::class)->create([
+            'email' => null,
+        ]);
+
+        $this->assertTrue($representativeA->hasEmail());
+        $this->assertFalse($representativeB->hasEmail());
+    }
 }

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -30,10 +30,10 @@ class PartnerRepresentativeTest extends TestCase
     /** @test */
     function can_have_an_optional_email_address()
     {
-        $representativeA = factory(PartnerRepresentative::class)->create([
+        $representativeA = factory(PartnerRepresentative::class)->make([
             'email' => 'henri@boucheriesanzot.be',
         ]);
-        $representativeB = factory(PartnerRepresentative::class)->create([
+        $representativeB = factory(PartnerRepresentative::class)->make([
             'email' => null,
         ]);
 
@@ -47,7 +47,7 @@ class PartnerRepresentativeTest extends TestCase
      */
     function the_email_address_must_be_valid()
     {
-        $representative = factory(PartnerRepresentative::class)->create([
+        $representative = factory(PartnerRepresentative::class)->make([
             'email' => 'invalid-email-address',
         ]);
     }

--- a/tests/Unit/PartnerTest.php
+++ b/tests/Unit/PartnerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Admin;
 use App\Partner;
 use App\Location;
 use Tests\TestCase;
+use App\PartnerRepresentative;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -72,5 +73,36 @@ class PartnerTest extends TestCase
 
         $this->assertSame($location2->id, $locations[1]->id);
         $this->assertSame('Magasin rue du Sud', $locations[1]->name);
+    }
+
+    /** @test */
+    function can_retrieve_its_representatives()
+    {
+        $partner = factory(Partner::class)->create([
+            'name' => 'Poissonnerie Ordralfabétix',
+        ]);
+
+        $personA = factory(PartnerRepresentative::class)->create([
+            'partner_id' => $partner->id,
+            'given_name' => 'Ordralfabétix',
+            'role' => 'gérant',
+        ]);
+        $personB = factory(PartnerRepresentative::class)->create([
+            'partner_id' => $partner->id,
+            'given_name' => 'Iélosubmarine',
+            'role' => 'gérante',
+        ]);
+
+        $representatives = $partner->representatives;
+
+        $this->assertCount(2, $representatives);
+
+        $this->assertSame($personA->id, $representatives[0]->id);
+        $this->assertSame('Ordralfabétix', $representatives[0]->given_name);
+        $this->assertSame('gérant', $representatives[0]->role);
+
+        $this->assertSame($personB->id, $representatives[1]->id);
+        $this->assertSame('Iélosubmarine', $representatives[1]->given_name);
+        $this->assertSame('gérante', $representatives[1]->role);
     }
 }


### PR DESCRIPTION
This pull request brings the concept of representatives — persons who are officially acting in the name of a partner.

Each partner can have one or more representatives, and each representative always belongs to just a single partner.