### PR TITLE
Add support for contact details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# Project-specific configuration
+# ------------------------------
+
+# The ISO 3166-1 alpha-2 code of the country where the currency is used.
+# See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+RADISSE_COUNTRY_CODE='BE';
+
+
 # General application configuration
 # ---------------------------------
 

--- a/app/ContactDetails.php
+++ b/app/ContactDetails.php
@@ -70,6 +70,16 @@ class ContactDetails extends Model
     }
 
     /**
+     * Get all of the owning contactable models.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function contactable()
+    {
+        return $this->morphTo('contactable');
+    }
+
+    /**
      * Get the key-value pairs of data that are specific to this type of contact info.
      *
      * This method has to be implemented by subclasses.

--- a/app/ContactDetails.php
+++ b/app/ContactDetails.php
@@ -21,6 +21,7 @@ class ContactDetails extends Model
 
     /**
      * The type of contact info stored by the object.
+     * This has to be set by subclasses.
      *
      * @var string
      */
@@ -49,6 +50,9 @@ class ContactDetails extends Model
     {
         parent::boot();
 
+        // When the contact info is retrieved from the database, we gather the
+        // contents of the JSON column in order to populate properties that
+        // are specific to the ContactDetails object we work with.
         static::registerModelEvent('retrieved', function (self $self) {
             $self->populateContactDetailProperties();
         });
@@ -72,7 +76,7 @@ class ContactDetails extends Model
     }
 
     /**
-     * Get the key-value pairs of data that are specific to this type of contact info.
+     * Get key-value pairs of data that are specific to this type of contact info.
      *
      * This method has to be implemented by subclasses.
      */

--- a/app/ContactDetails.php
+++ b/app/ContactDetails.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 
 class ContactDetails extends Model

--- a/app/ContactDetails.php
+++ b/app/ContactDetails.php
@@ -50,7 +50,7 @@ class ContactDetails extends Model
         parent::boot();
 
         static::registerModelEvent('retrieved', function (self $self) {
-            $self->convertAttributesToProperties();
+            $self->populateContactDetailProperties();
         });
 
         // When the contact info is saved to the database, we gather the
@@ -198,7 +198,7 @@ class ContactDetails extends Model
         return $model;
     }
 
-    protected function convertAttributesToProperties()
+    protected function populateContactDetailProperties()
     {
         $data = json_decode($this->attributes['data']);
 

--- a/app/ContactDetails.php
+++ b/app/ContactDetails.php
@@ -57,19 +57,7 @@ class ContactDetails extends Model
         // data that is related to the ContactDetails object in order
         // to store it as JSON in a dedicated database column.
         static::saving(function (self $self) {
-
-            $commonData = [
-                'isPublic' => $self->isPublic,
-                'label' => $self->label,
-            ];
-
-            $specificData = $self->getOwnAttributes();
-
-            // Overwrite the array of attributes of the Eloquent model.
-            $self->attributes = array_merge($self->attributes, [
-                'type' => $self->type,
-                'data' => json_encode($commonData + $specificData),
-            ]);
+            $self->prepareContactDetailPropertiesForSaving();
         });
     }
 
@@ -216,5 +204,20 @@ class ContactDetails extends Model
         foreach ($properties as $property) {
             $this->{$property} = $data->{$property};
         }
+    }
+    protected function prepareContactDetailPropertiesForSaving()
+    {
+        $commonData = [
+            'isPublic' => $this->isPublic,
+            'label' => $this->label,
+        ];
+
+        $specificData = $this->getOwnAttributes();
+
+        // Overwrite the array of attributes of the Eloquent model.
+        $this->attributes = array_merge($this->attributes, [
+            'type' => $this->type,
+            'data' => json_encode($commonData + $specificData),
+        ]);
     }
 }

--- a/app/ContactDetails.php
+++ b/app/ContactDetails.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ContactDetails extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * We explicitly define this property here in order to make subclasses
+     * automatically inherit it. This prevents Eloquent to try to guess
+     * the proper table names for subclasses from their names. This
+     * is needed because they all use the contact_details table.
+     *
+     * @var string
+     */
+    protected $table = 'contact_details';
+
+    /**
+     * The type of contact info stored by the object.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Tell if the info is public or if it can only be used internally.
+     *
+     * @var bool
+     */
+    protected $isPublic = false;
+
+    /**
+     * An optional label associated with the contact info.
+     *
+     * @var string
+     */
+    protected $label;
+
+    /**
+     * The "booting" method of the model.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        // When the contact info is saved to the database, we gather the
+        // data that is related to the ContactDetails object in order
+        // to store it as JSON in a dedicated database column.
+        self::saving(function (self $self) {
+
+            $commonData = [
+                'isPublic' => $self->isPublic,
+                'label' => $self->label,
+            ];
+
+            $specificData = $self->getOwnAttributes();
+
+            // Overwrite the array of attributes of the Eloquent model.
+            $self->attributes = array_merge($self->attributes, [
+                'type' => $self->type,
+                'data' => json_encode($commonData + $specificData),
+            ]);
+        });
+    }
+
+    /**
+     * Get the key-value pairs of data that are specific to this type of contact info.
+     *
+     * This method has to be implemented by subclasses.
+     */
+    protected function getOwnAttributes()
+    {
+        throw new Exception(
+            'getOwnAttributes method must be overwritten by subclasses'
+        );
+    }
+
+    /**
+     * Allow to fluently set the public state a contact info.
+     *
+     * @return self
+     */
+    public function makePublic()
+    {
+        $this->isPublic = true;
+
+        return $this;
+    }
+
+    /**
+     * Allow to fluently set the private state a contact info.
+     *
+     * @return self
+     */
+    public function makePrivate()
+    {
+        $this->isPublic = false;
+
+        return $this;
+    }
+
+    /**
+     * Allow to fluently add a label to a contact info.
+     *
+     * @param  string  $label
+     *
+     * @return self
+     */
+    public function withLabel($label)
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Allow to read specific properties as if they were public.
+     *
+     * @param  string  $name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'type':
+                return $this->type;
+            case 'isPublic':
+                return $this->isPublic;
+            case 'isPrivate':
+                return !$this->isPublic;
+            case 'label':
+                return $this->label;
+        }
+
+        return parent::__get($name);
+    }
+
+    /**
+     * Allow to write specific properties as if they were public.
+     *
+     * @param string  $name
+     * @param mixed   $value
+     */
+    public function __set($name, $value)
+    {
+        switch ($name) {
+            case 'label':
+                $this->label = ($label = trim($value)) ? $label : null;
+                break;
+            case 'isPublic':
+                $this->isPublic = (bool) $value;
+                break;
+            case 'isPrivate':
+                $this->isPublic = !((bool) $value);
+                break;
+            default:
+                // Fall back on the magic method of the parent.
+                parent::__set($name, $value);
+                break;
+        }
+    }
+
+    /**
+     * Create a new model instance that is existing.
+     *
+     * @param  array  $attributes
+     * @param  string|null  $connection
+     * @return static
+     */
+    public function newFromBuilder($attributes = [], $connection = null)
+    {
+        // First, retrieve the model using the original method.
+        $model = parent::newFromBuilder($attributes, $connection);
+
+        $data = json_decode($model->attributes['data']);
+
+        // Handle properties that are shared by all types of contact details.
+        $model->isPublic = $data->isPublic;
+        $model->label = $data->label;
+
+        // Then, handle specific properties.
+        if (method_exists($model, 'getOwnAttributeKeys')) {
+            $properties = $model->getOwnAttributeKeys();
+        } else {
+            $properties = array_keys($model->getOwnAttributes());
+        }
+
+        foreach ($properties as $property) {
+            $model->{$property} = $data->{$property};
+        }
+
+        return $model;
+    }
+}

--- a/app/ContactDetails.php
+++ b/app/ContactDetails.php
@@ -186,6 +186,14 @@ class ContactDetails extends Model
         return $model;
     }
 
+    /**
+     * Initialize specific properties based on a JSON database column.
+     *
+     * This fills properties related to the contact detail from data that is
+     * stored in a dedicated JSON column.
+     *
+     * @return void
+     */
     protected function populateContactDetailProperties()
     {
         $data = json_decode($this->attributes['data']);
@@ -205,6 +213,15 @@ class ContactDetails extends Model
             $this->{$property} = $data->{$property};
         }
     }
+
+    /**
+     * Set or update Eloquent attributes using data from specific properties.
+     *
+     * This gathers data from properties that are specific to the contact
+     * detail in order to store it in a dedicated JSON column.
+     *
+     * @return void
+     */
     protected function prepareContactDetailPropertiesForSaving()
     {
         $commonData = [

--- a/app/Email.php
+++ b/app/Email.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App;
+
+use DomainException;
+use Email\Parse as EmailParser;
+
+class Email extends ContactDetails
+{
+    /**
+     * The type of contact info stored by the object.
+     *
+     * @var string
+     */
+    protected $type = 'email';
+
+    /**
+     * The components of the e-mail address.
+     *
+     * @var array
+     */
+    protected $parts;
+
+    /**
+     * Create a new instance from an e-mail address.
+     *
+     * @param  string  $address
+     *
+     * @return self
+     *
+     * @throws \DomainException if the e-mail address is invalid.
+     */
+    public static function fromAddress($address)
+    {
+        $email = new self;
+
+        // We store the components of the address, not the address itself.
+        $email->parts = $email->parseEmail($address);
+
+        return $email;
+    }
+
+    /**
+     * Helper to parse an e-mail address and get its components.
+     *
+     * @param  string  $address
+     *
+     * @return array
+     *
+     * @throws \DomainException if the e-mail address is invalid.
+     */
+    protected function parseEmail($address)
+    {
+        $result = EmailParser::getInstance()->parse($address);
+
+        if ($result['success'] === false) {
+            throw new DomainException("[{$address}] is an invalid e-mail address.");
+        }
+
+        return $result['email_addresses'][0];
+    }
+
+    /**
+     * Get the key-value pairs of data that are specific to this type of contact info.
+     *
+     * @return array
+     */
+    protected function getOwnAttributes()
+    {
+        return [
+            'address' => $this->address,
+        ];
+    }
+
+    /**
+     * Allow to read specific properties as if they were public.
+     *
+     * @param  string  $name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'localPart':
+                return $this->parts['local_part'];
+            case 'domain':
+                return $this->parts['domain'];
+            case 'address':
+                return $this->parts['local_part'].'@'.$this->parts['domain'];
+        }
+
+        return parent::__get($name);
+    }
+
+    /**
+     * Allow to write specific properties as if they were public.
+     *
+     * @param string  $name
+     * @param mixed   $value
+     */
+    public function __set($name, $value)
+    {
+        switch ($name) {
+            case 'localPart':
+                $this->parts['local_part'] = $value;
+                break;
+            case 'domain':
+                $this->parts['domain'] = $value;
+                break;
+            case 'address':
+                // We store the components of the address, not the address itself.
+                $this->parts = $this->parseEmail($value);
+                break;
+            default:
+                // Fall back on the magic method of the parent.
+                parent::__set($name, $value);
+                break;
+        }
+    }
+
+    /**
+     * Convert the e-mail to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->address;
+    }
+}

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -63,4 +63,48 @@ class Partner extends Model
     {
         return $this->hasMany(PartnerRepresentative::class);
     }
+
+    /**
+     * Get all of the partner’s postal addresses.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function postalAddresses()
+    {
+        return $this->morphMany(PostalAddress::class, 'contactable')
+            ->where('type', 'postal-address');
+    }
+
+    /**
+     * Get all of the partner’s phones.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function phones()
+    {
+        return $this->morphMany(Phone::class, 'contactable')
+            ->where('type', 'phone');
+    }
+
+    /**
+     * Get all of the partner’s emails.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function emails()
+    {
+        return $this->morphMany(Email::class, 'contactable')
+            ->where('type', 'email');
+    }
+
+    /**
+     * Get all of the partner’s social networks.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function socialNetworks()
+    {
+        return $this->morphMany(SocialNetwork::class, 'contactable')
+            ->where('type', 'social-network');
+    }
 }

--- a/app/Phone.php
+++ b/app/Phone.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App;
+
+use DomainException;
+use Propaganistas\LaravelPhone\PhoneNumber;
+
+class Phone extends ContactDetails
+{
+    /**
+     * The type of contact info stored by the object.
+     *
+     * @var string
+     */
+    protected $type = 'phone';
+
+    /**
+     * The ISO 3166-1 alpha-2 code of the country where the currency is used.
+     * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+     *
+     * @var string
+     */
+    protected $countryCode;
+
+    /**
+     * The phone number, formatted in international format.
+     *
+     * @var string
+     */
+    protected $number;
+
+    /**
+     * Create a new ContactDetails model instance of type ‘phone’.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->countryCode = config('radisse.country_code');
+    }
+
+    /**
+     * Create a new instance from a phone number given as a string.
+     *
+     * @param  string  $number
+     *
+     * @return self
+     *
+     * @throws \DomainException if the phone number is invalid.
+     */
+    public static function fromNumber($number)
+    {
+        $phone = new self;
+
+        // Calling the magic method allows us to centralize validation
+        // and formatting there instead of duplicating code.
+        $phone->__set('number', $number);
+
+        return $phone;
+    }
+
+    /**
+     * Format the phone number in national format.
+     *
+     * @return string
+     */
+    public function toNationalFormat()
+    {
+        return $this->toPhoneObject()->formatNational();
+    }
+
+    /**
+     * Format the phone number in international format.
+     *
+     * @return string
+     */
+    public function toInternationalFormat()
+    {
+        return $this->toPhoneObject()->formatInternational();
+    }
+
+    /**
+     * Format the phone number in the E.164 format.
+     * @see https://en.wikipedia.org/wiki/E.164
+     *
+     * @return string
+     */
+    public function toE164Format()
+    {
+        return $this->toPhoneObject()->formatE164();
+    }
+
+    /**
+     * Create a PhoneNumber instance from the data of the model.
+     *
+     * @param  string|null  $number
+     * @param  string|null  $countryCode
+     *
+     * @return \Propaganistas\LaravelPhone\PhoneNumber
+     */
+    protected function toPhoneObject($number = null, $countryCode = null)
+    {
+        return PhoneNumber::make(
+            $number ?? $this->number,
+            $country_code ?? $this->countryCode
+        );
+    }
+
+    /**
+     * Check if a given phone number is valid.
+     *
+     * @param  string  $number
+     * @param  string  $countryCode
+     *
+     * @return void
+     *
+     * @throws \DomainException if the phone number is invalid.
+     */
+    protected function validatePhoneNumber($number, $countryCode)
+    {
+        if (validator([$number], ['phone:'.$countryCode])->fails()) {
+            throw new DomainException("[{$number}] is an invalid phone number.");
+        }
+    }
+
+    /**
+     * Get the key-value pairs of data that are specific to this type of contact info.
+     *
+     * @return array
+     */
+    protected function getOwnAttributes()
+    {
+        return [
+            'number' => $this->toE164Format(),
+        ];
+    }
+
+    /**
+     * Get the keys that are specific to this type of contact info.
+     *
+     * @return array
+     */
+    protected function getOwnAttributeKeys()
+    {
+        return ['number'];
+    }
+
+    /**
+     * Allow to read specific properties as if they were public.
+     *
+     * @param  string  $name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        if ($name === 'number') {
+            return $this->number;
+        }
+
+        return parent::__get($name);
+    }
+
+    /**
+     * Allow to write specific properties as if they were public.
+     *
+     * @param string  $name
+     * @param mixed   $value
+     */
+    public function __set($name, $value)
+    {
+        if ($name === 'number') {
+            // Ensure the number has a valid syntax.
+            $this->validatePhoneNumber($value, $this->countryCode);
+
+            // Format it in international format before storing it internally.
+            $this->number = $this->toPhoneObject($value)->formatInternational();
+        } else {
+            // Fall back on the magic method of the parent.
+            parent::__set($name, $value);
+        }
+    }
+
+    /**
+     * Convert the phone number to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toInternationalFormat();
+    }
+}

--- a/app/PostalAddress.php
+++ b/app/PostalAddress.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace App;
+
+use stdClass;
+use DomainException;
+use CommerceGuys\Addressing\Model\Address;
+use CommerceGuys\Addressing\Formatter\DefaultFormatter;
+use CommerceGuys\Addressing\Repository\CountryRepository;
+use CommerceGuys\Addressing\Repository\SubdivisionRepository;
+use CommerceGuys\Addressing\Repository\AddressFormatRepository;
+use Symfony\Component\Validator\Validation as SymfonyValidator;
+use CommerceGuys\Addressing\Validator\Constraints\Country as CountryRule;
+use CommerceGuys\Addressing\Validator\Constraints\AddressFormat as AddressFormatRule;
+
+class PostalAddress extends ContactDetails
+{
+    /**
+     * The type of contact info stored by the object.
+     *
+     * @var string
+     */
+    protected $type = 'postal-address';
+
+    /**
+     * The ISO 3166-1 alpha-2 code of the country where the currency is used.
+     * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+     *
+     * @var string
+     */
+    protected $countryCode;
+
+    /**
+     * The components of the postal address.
+     *
+     * @var \stdClass
+     */
+    protected $parts;
+
+    /**
+     * Create a new ContactDetails model instance of type ‘postal-address’.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->countryCode = config('radisse.country_code');
+    }
+
+    /**
+     * Create a new instance from an array of address components.
+     *
+     * @param  array  $parts
+     *
+     * @return self
+     */
+    public static function fromArray(array $parts)
+    {
+        $address = new self;
+
+        // Convert the array of data to an instance of \stdClass.
+        $parts = (object) $parts;
+
+        // Ensure we got the required address components.
+        $address->validateAddress($parts);
+
+        // We store the components of the address, not the address itself.
+        $address->parts = $parts;
+
+        return $address;
+    }
+
+    /**
+     * Create a CommerceGuys Address instance from the data of the model.
+     *
+     * @param  \stdClass|null  $parts
+     *
+     * @return \CommerceGuys\Addressing\Model\Address
+     */
+    protected function toAddressObject(stdClass $parts = null)
+    {
+        // Use the internal data if no argument has been passed.
+        $parts = $parts ?? $this->parts;
+
+        $this->validatePresenceOfRequiredAddressParts($parts);
+
+        return (new Address)
+            ->withRecipient($parts->recipient)
+            ->withAddressLine1($this->formatAddressLine1($parts))
+            ->withPostalCode($parts->postal_code)
+            ->withLocality($parts->city)
+            ->withCountryCode($this->countryCode)
+            ->withLocale(config('app.locale'));
+    }
+
+    /**
+     * Helper method to format an address line from address parts.
+     *
+     * @param  \stdClass  $parts
+     *
+     * @return string
+     */
+    protected function formatAddressLine1(stdClass $parts)
+    {
+        $addressLine = $parts->street.' '.$parts->street_number;
+
+        if (isset($parts->letter_box)) {
+            $addressLine .= ' bte '.$parts->letter_box;
+        }
+
+        return $addressLine;
+    }
+
+    /**
+     * Check if a given postal address is valid.
+     *
+     * @param  stdClass|\CommerceGuys\Addressing\Model\Address  $address
+     *
+     * @return void
+     *
+     * @throws \DomainException if the postal address is invalid.
+     */
+    protected function validateAddress($address)
+    {
+        if ($address instanceof stdClass) {
+            $address = $this->toAddressObject($address);
+        }
+
+        $validator = SymfonyValidator::createValidator();
+
+        // First, we validate the country code.
+        $violations = $validator->validate(
+            $address->getCountryCode(),
+            new CountryRule
+        );
+
+        if ($violations->count()) {
+            throw new DomainException($violations->__toString());
+        }
+
+        // Second, we validate the rest of the address.
+        $violations = $validator->validate($address, new AddressFormatRule);
+
+        if ($violations->count()) {
+            throw new DomainException($violations->__toString());
+        }
+    }
+
+    /**
+     * Check if all of the required components of an address are present.
+     *
+     * @param  \stdClass  $address
+     *
+     * @return void
+     *
+     * @throws \DomainException if at least one component is missing.
+     */
+    protected function validatePresenceOfRequiredAddressParts(stdClass $address)
+    {
+        $requiredParts = [
+            'recipient',
+            'street', 'street_number',
+            'postal_code', 'city'
+        ];
+
+        foreach ($requiredParts as $part) {
+            if (!isset($address->{$part})) {
+                throw new DomainException("Missing components in postal address.");
+            }
+        }
+    }
+
+    /**
+     * Get the key-value pairs of data that are specific to this type of contact info.
+     *
+     * @return array
+     */
+    protected function getOwnAttributes()
+    {
+        return [
+            'parts' => $this->parts,
+        ];
+    }
+
+    /**
+     * Allow to read specific properties as if they were public.
+     *
+     * @param  string  $name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'recipient':
+            case 'street':
+            case 'streetNumber':
+            case 'letterBox':
+            case 'postalCode':
+            case 'city':
+            case 'latitude':
+            case 'longitude':
+                // dd($this->parts);
+                return $this->parts->{snake_case($name)};
+        }
+
+        return parent::__get($name);
+    }
+
+    /**
+     * Allow to write specific properties as if they were public.
+     *
+     * @param string  $name
+     * @param mixed   $value
+     */
+    public function __set($name, $value)
+    {
+        switch ($name) {
+            case 'recipient':
+            case 'street':
+            case 'streetNumber':
+            case 'letterBox':
+            case 'postalCode':
+            case 'city':
+            case 'latitude':
+            case 'longitude':
+                // Update the value.
+                $this->parts->{snake_case($name)} = $value;
+
+                // Ensure we got the required address components.
+                $this->validateAddress($this->parts);
+                break;
+            default:
+                // Fall back on the magic method of the parent.
+                parent::__set($name, $value);
+                break;
+        }
+    }
+
+    /**
+     * Convert the address to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $address = $this->toAddressObject();
+
+        return $this->getFormatter()->format($address);
+    }
+
+    /**
+     * Get a postal address formatter
+     *
+     * @return \CommerceGuys\Addressing\Formatter\DefaultFormatter
+     */
+    protected function getFormatter()
+    {
+        return new DefaultFormatter(
+            new AddressFormatRepository,
+            new CountryRepository,
+            new SubdivisionRepository,
+            $locale = config('app.locale'),
+            $options = ['html' => false]
+        );
+    }
+}

--- a/app/SocialNetwork.php
+++ b/app/SocialNetwork.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App;
+
+use DomainException;
+
+class SocialNetwork extends ContactDetails
+{
+    /**
+     * The type of contact info stored by the object.
+     *
+     * @var string
+     */
+    protected $type = 'social-network';
+
+    /**
+     * The name of the social network, in lowercase.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The identifier that is related to the social network.
+     *
+     * @var string
+     */
+    protected $handle;
+
+    /**
+     * A list of supported networks and, for each, patterns to work with it.
+     *
+     * @var array
+     */
+    protected $supportedNetworks = [
+        'facebook' => [
+            'regex' => '#^facebook.com/([0-9A-Za-z.-]+)$#',
+            'url_format' => 'https://www.facebook.com/:handle:',
+        ],
+        'twitter' => [
+            'regex' => '#^twitter.com/([0-9A-Za-z._-]+)$#',
+            'url_format' => 'https://twitter.com/:handle:',
+        ],
+    ];
+
+    /**
+     * Create a new instance from a URL.
+     *
+     * @param  string  $url
+     *
+     * @return self
+     *
+     * @throws \DomainException if no social netwwork can be detected.
+     */
+    public static function fromUrl($url)
+    {
+        $network = new self;
+
+        [$network->name, $network->handle] = $network->detectTypeAndHandle($url);
+
+        return $network;
+    }
+
+    /**
+     * Helper to parse the URL of a social network and extract its handle.
+     *
+     * @param  string  $url
+     *
+     * @return array   The first index is the name of the social network,
+     *                 in lowercase. The second index is the handle.
+     *
+     * @throws \DomainException if no social netwwork can be detected.
+     */
+    protected function detectTypeAndHandle($url)
+    {
+        // First, clean the URL from protocol stuff.
+        $url = preg_replace('#https?://|www\.#', '', $url);
+
+        // Then, look for a supported social network.
+        foreach ($this->supportedNetworks as $network => $patterns) {
+            if ($handle = $this->findHandle($url, $network)) {
+                return [$network, $handle];
+            }
+        }
+
+        throw new DomainException("Cannot detect social network from [{$url}].");
+    }
+
+    /**
+     * Try to extract the handle from the URL of a social network.
+     *
+     * @param  string  $url      The URL to analyze
+     * @param  string  $network  The name of the social network, in lowercase
+     *
+     * @return string|false
+     */
+    protected function findHandle($url, $network)
+    {
+        $regex = $this->supportedNetworks[$network]['regex'];
+        $matches = [];
+
+        if (preg_match($regex, $url, $matches)) {
+            return $matches[1];
+        }
+
+        return false;
+    }
+
+    /**
+     * Build the URL from the network and the handle.
+     *
+     * @return string
+     */
+    protected function getUrl()
+    {
+        try {
+            $subject = $this->supportedNetworks[$this->name]['url_format'];
+
+        } catch (\Exception $e) {
+            dd($this);
+        }
+
+        return preg_replace('#:handle:#', $this->handle, $subject);
+    }
+
+    /**
+     * Get the key-value pairs of data that are specific to this type of contact info.
+     *
+     * @return array
+     */
+    protected function getOwnAttributes()
+    {
+        return [
+            'name' => $this->name,
+            'handle' => $this->handle,
+        ];
+    }
+
+    /**
+     * Allow to read specific properties as if they were public.
+     *
+     * @param  string  $name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'name':
+                return $this->name;
+            case 'handle':
+                return $this->handle;
+            case 'url':
+                return $this->getUrl();
+        }
+
+        return parent::__get($name);
+    }
+
+    /**
+     * Allow to write specific properties as if they were public.
+     *
+     * @param string  $name
+     * @param mixed   $value
+     */
+    public function __set($name, $value)
+    {
+        switch ($name) {
+            case 'name':
+                $this->name = $value;
+                break;
+            case 'handle':
+                $this->handle = $value;
+                break;
+            default:
+                // Fall back on the magic method of the parent.
+                parent::__set($name, $value);
+                break;
+        }
+    }
+
+    /**
+     * Convert the e-mail to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->url;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,13 @@
     ],
     "require": {
         "php": ">=5.6.4",
+        "commerceguys/addressing": "^0.8.4",
+        "commerceguys/intl": "^0.7.4",
         "laravel/framework": "5.4.*",
         "laravel/tinker": "~1.0",
-        "propaganistas/laravel-phone": "^3.0"
+        "mmucklo/email-parse": "^2.0",
+        "propaganistas/laravel-phone": "^3.0",
+        "symfony/validator": "^3.3"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,185 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba0c41a7f74d41d8aec98095a60fc9c1",
+    "content-hash": "ed975628660b16688d14da13d91faf44",
     "packages": [
+        {
+            "name": "commerceguys/addressing",
+            "version": "v0.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commerceguys/addressing.git",
+                "reference": "5d8d13bfaed08119be763da2a0fc9f38fff8af54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/5d8d13bfaed08119be763da2a0fc9f38fff8af54",
+                "reference": "5d8d13bfaed08119be763da2a0fc9f38fff8af54",
+                "shasum": ""
+            },
+            "require": {
+                "commerceguys/enum": "~1.0",
+                "doctrine/collections": "~1.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "1.*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "2.*",
+                "symfony/intl": ">=2.3",
+                "symfony/validator": ">=2.3"
+            },
+            "suggest": {
+                "commerceguys/intl": "to use it as the source of country data",
+                "symfony/form": "to generate Symfony address forms",
+                "symfony/intl": "to use it as the source of country data",
+                "symfony/validator": "to validate addresses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CommerceGuys\\Addressing\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bojan Zivanovic"
+                },
+                {
+                    "name": "Damien Tournoud"
+                }
+            ],
+            "description": "Addressing library powered by Google's address data.",
+            "keywords": [
+                "address",
+                "internationalization",
+                "localization",
+                "postal"
+            ],
+            "time": "2016-09-05T18:45:53+00:00"
+        },
+        {
+            "name": "commerceguys/enum",
+            "version": "v1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commerceguys/enum.git",
+                "reference": "1d9db2dbeb1a02500e7a14589ae2f9cb402c5c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commerceguys/enum/zipball/1d9db2dbeb1a02500e7a14589ae2f9cb402c5c95",
+                "reference": "1d9db2dbeb1a02500e7a14589ae2f9cb402c5c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CommerceGuys\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bojan Zivanovic"
+                }
+            ],
+            "description": "A PHP 5.4+ enumeration library.",
+            "time": "2015-02-27T21:36:56+00:00"
+        },
+        {
+            "name": "commerceguys/intl",
+            "version": "v0.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commerceguys/intl.git",
+                "reference": "edfcfc26ed8505c4f6fcf862eb36dfda1af74b00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commerceguys/intl/zipball/edfcfc26ed8505c4f6fcf862eb36dfda1af74b00",
+                "reference": "edfcfc26ed8505c4f6fcf862eb36dfda1af74b00",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "1.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CommerceGuys\\Intl\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bojan Zivanovic"
+                }
+            ],
+            "description": "Internationalization library powered by CLDR data.",
+            "time": "2016-12-13T12:33:19+00:00"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
         {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "0.1",
@@ -40,34 +217,101 @@
             "time": "2014-10-24T07:27:01+00:00"
         },
         {
-            "name": "doctrine/inflector",
-            "version": "v1.1.0",
+            "name": "doctrine/collections",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/inflector.git",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
-                    "Doctrine\\Common\\Inflector\\": "lib/"
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-07-22T10:37:32+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -104,7 +348,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2017-07-22T12:18:28+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -150,16 +394,16 @@
         },
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "8.7.0",
+            "version": "8.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "dd9cf2a10a8671d3934a7a315e927df46548bcc9"
+                "reference": "d234fc851e71443f20325501d1b764af488b0a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/dd9cf2a10a8671d3934a7a315e927df46548bcc9",
-                "reference": "dd9cf2a10a8671d3934a7a315e927df46548bcc9",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/d234fc851e71443f20325501d1b764af488b0a66",
+                "reference": "d234fc851e71443f20325501d1b764af488b0a66",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +414,7 @@
             "require-dev": {
                 "pear/pear-core-minimal": "^1.9",
                 "pear/pear_exception": "^1.0",
-                "pear/versioncontrol_git": "dev-master",
+                "pear/versioncontrol_git": "^0.5",
                 "phing/phing": "^2.7",
                 "phpunit/phpunit": "^4.8|^5.0",
                 "satooshi/php-coveralls": "^1.0",
@@ -214,7 +458,7 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2017-07-18T13:07:45+00:00"
+            "time": "2017-09-06T08:32:29+00:00"
         },
         {
             "name": "giggsey/locale",
@@ -387,20 +631,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.4.28",
+            "version": "v5.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "442511fc62121085d184355e4f964c88942bbecb"
+                "reference": "1062a22232071c3e8636487c86ec1ae75681bbf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/442511fc62121085d184355e4f964c88942bbecb",
-                "reference": "442511fc62121085d184355e4f964c88942bbecb",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/1062a22232071c3e8636487c86ec1ae75681bbf9",
+                "reference": "1062a22232071c3e8636487c86ec1ae75681bbf9",
                 "shasum": ""
             },
             "require": {
-                "doctrine/inflector": "~1.0",
+                "doctrine/inflector": "~1.1",
                 "erusev/parsedown": "~1.6",
                 "ext-mbstring": "*",
                 "ext-openssl": "*",
@@ -512,20 +756,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2017-06-30T13:43:07+00:00"
+            "time": "2017-08-30T09:26:16+00:00"
         },
         {
             "name": "laravel/tinker",
-            "version": "v1.0.1",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "7eb2e281395131897407285672ef5532e87e17f9"
+                "reference": "203978fd67f118902acff95925847e70b72e3daf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/7eb2e281395131897407285672ef5532e87e17f9",
-                "reference": "7eb2e281395131897407285672ef5532e87e17f9",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/203978fd67f118902acff95925847e70b72e3daf",
+                "reference": "203978fd67f118902acff95925847e70b72e3daf",
                 "shasum": ""
             },
             "require": {
@@ -575,20 +819,20 @@
                 "laravel",
                 "psysh"
             ],
-            "time": "2017-06-01T16:31:26+00:00"
+            "time": "2017-07-13T13:11:05+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.40",
+            "version": "1.0.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "3828f0b24e2c1918bb362d57a53205d6dc8fde61"
+                "reference": "f400aa98912c561ba625ea4065031b7a41e5a155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3828f0b24e2c1918bb362d57a53205d6dc8fde61",
-                "reference": "3828f0b24e2c1918bb362d57a53205d6dc8fde61",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f400aa98912c561ba625ea4065031b7a41e5a155",
+                "reference": "f400aa98912c561ba625ea4065031b7a41e5a155",
                 "shasum": ""
             },
             "require": {
@@ -609,13 +853,13 @@
                 "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
                 "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
                 "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-                "league/flysystem-copy": "Allows you to use Copy.com storage",
                 "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
                 "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
                 "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
                 "league/flysystem-webdav": "Allows you to use WebDAV storage",
                 "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage"
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
             },
             "type": "library",
             "extra": {
@@ -658,7 +902,60 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-04-28T10:15:08+00:00"
+            "time": "2017-08-06T17:41:04+00:00"
+        },
+        {
+            "name": "mmucklo/email-parse",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mmucklo/email-parse.git",
+                "reference": "6d1b481d40e01f314ea4d13c1e7f30df3673a371"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mmucklo/email-parse/zipball/6d1b481d40e01f314ea4d13c1e7f30df3673a371",
+                "reference": "6d1b481d40e01f314ea4d13c1e7f30df3673a371",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0",
+                "psr/log": "~1.0",
+                "true/punycode": "~2.0",
+                "zendframework/zend-validator": ">=2.0,<=3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "dev-master",
+                "phpunit/phpunit": "^5.7.0",
+                "symfony/yaml": ">=2.7,<=2.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Email\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew J. Mucklo",
+                    "email": "mmucklo@gmail.com"
+                }
+            ],
+            "description": "email-parse a (reasonably) RFC822 / RF2822-compliant library for batch parsing multiple (and single) email addresses",
+            "keywords": [
+                "RFC2822",
+                "RFC822",
+                "batch-email",
+                "email",
+                "email-parse",
+                "multiple-email",
+                "parse"
+            ],
+            "time": "2017-04-15T01:57:03+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -837,16 +1134,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.0.6",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0808939f81c1347a3c8a82a5925385a08074b0f1"
+                "reference": "a1e8e1a30e1352f118feff1a8481066ddc2f234a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0808939f81c1347a3c8a82a5925385a08074b0f1",
-                "reference": "0808939f81c1347a3c8a82a5925385a08074b0f1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a1e8e1a30e1352f118feff1a8481066ddc2f234a",
+                "reference": "a1e8e1a30e1352f118feff1a8481066ddc2f234a",
                 "shasum": ""
             },
             "require": {
@@ -884,7 +1181,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-06-28T20:53:48+00:00"
+            "time": "2017-09-02T17:10:46+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -936,16 +1233,16 @@
         },
         {
             "name": "propaganistas/laravel-phone",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Propaganistas/Laravel-Phone.git",
-                "reference": "48584eda0f5275f7d35e7ce15f26951b9a34b545"
+                "reference": "a404e65956ff9de2d1c54e0916601f72a029d2b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Propaganistas/Laravel-Phone/zipball/48584eda0f5275f7d35e7ce15f26951b9a34b545",
-                "reference": "48584eda0f5275f7d35e7ce15f26951b9a34b545",
+                "url": "https://api.github.com/repos/Propaganistas/Laravel-Phone/zipball/a404e65956ff9de2d1c54e0916601f72a029d2b3",
+                "reference": "a404e65956ff9de2d1c54e0916601f72a029d2b3",
                 "shasum": ""
             },
             "require": {
@@ -996,7 +1293,56 @@
                 "phone",
                 "validation"
             ],
-            "time": "2017-07-25T18:22:59+00:00"
+            "time": "2017-08-22T07:04:17+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
@@ -1047,16 +1393,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.8.9",
+            "version": "v0.8.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "58a31cc4404c8f632d8c557bc72056af2d3a83db"
+                "reference": "b193cd020e8c6b66cea6457826ae005e94e6d2c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/58a31cc4404c8f632d8c557bc72056af2d3a83db",
-                "reference": "58a31cc4404c8f632d8c557bc72056af2d3a83db",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/b193cd020e8c6b66cea6457826ae005e94e6d2c0",
+                "reference": "b193cd020e8c6b66cea6457826ae005e94e6d2c0",
                 "shasum": ""
             },
             "require": {
@@ -1116,20 +1462,20 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2017-07-06T14:53:52+00:00"
+            "time": "2017-07-29T19:30:02+00:00"
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.6.1",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "4ae32dd9ab8860a4bbd750ad269cba7f06f7934e"
+                "reference": "0ef23d1b10cf1bc576e9d865a7e9c47982c5715e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/4ae32dd9ab8860a4bbd750ad269cba7f06f7934e",
-                "reference": "4ae32dd9ab8860a4bbd750ad269cba7f06f7934e",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/0ef23d1b10cf1bc576e9d865a7e9c47982c5715e",
+                "reference": "0ef23d1b10cf1bc576e9d865a7e9c47982c5715e",
                 "shasum": ""
             },
             "require": {
@@ -1198,7 +1544,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2017-03-26T20:37:53+00:00"
+            "time": "2017-08-04T13:39:04+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -1256,20 +1602,20 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a97e45d98c59510f085fa05225a1acb74dfe0546"
+                "reference": "a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a97e45d98c59510f085fa05225a1acb74dfe0546",
-                "reference": "a97e45d98c59510f085fa05225a1acb74dfe0546",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf",
+                "reference": "a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
@@ -1282,7 +1628,6 @@
                 "symfony/dependency-injection": "~3.3",
                 "symfony/event-dispatcher": "~2.8|~3.0",
                 "symfony/filesystem": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0",
                 "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
@@ -1321,24 +1666,24 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-03T13:19:36+00:00"
+            "time": "2017-09-06T16:40:18+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "4d882dced7b995d5274293039370148e291808f2"
+                "reference": "c5f5263ed231f164c58368efbce959137c7d9488"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/4d882dced7b995d5274293039370148e291808f2",
-                "reference": "4d882dced7b995d5274293039370148e291808f2",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/c5f5263ed231f164c58368efbce959137c7d9488",
+                "reference": "c5f5263ed231f164c58368efbce959137c7d9488",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
@@ -1374,24 +1719,24 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01T15:01:29+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "63b85a968486d95ff9542228dc2e4247f16f9743"
+                "reference": "8beb24eec70b345c313640962df933499373a944"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/63b85a968486d95ff9542228dc2e4247f16f9743",
-                "reference": "63b85a968486d95ff9542228dc2e4247f16f9743",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/8beb24eec70b345c313640962df933499373a944",
+                "reference": "8beb24eec70b345c313640962df933499373a944",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "psr/log": "~1.0"
             },
             "conflict": {
@@ -1430,24 +1775,24 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-05T13:02:37+00:00"
+            "time": "2017-09-01T13:23:39+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "67535f1e3fd662bdc68d7ba317c93eecd973617e"
+                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67535f1e3fd662bdc68d7ba317c93eecd973617e",
-                "reference": "67535f1e3fd662bdc68d7ba317c93eecd973617e",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/54ca9520a00386f83bca145819ad3b619aaa2485",
+                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.3"
@@ -1493,24 +1838,24 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-09T14:53:08+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4"
+                "reference": "b2260dbc80f3c4198f903215f91a1ac7fe9fe09e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/baea7f66d30854ad32988c11a09d7ffd485810c4",
-                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/b2260dbc80f3c4198f903215f91a1ac7fe9fe09e",
+                "reference": "b2260dbc80f3c4198f903215f91a1ac7fe9fe09e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
@@ -1542,24 +1887,24 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T21:01:25+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "f347a5f561b03db95ed666959db42bbbf429b7e5"
+                "reference": "2cdc7de1921d1a1c805a13dc05e44a2cd58f5ad3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f347a5f561b03db95ed666959db42bbbf429b7e5",
-                "reference": "f347a5f561b03db95ed666959db42bbbf429b7e5",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/2cdc7de1921d1a1c805a13dc05e44a2cd58f5ad3",
+                "reference": "2cdc7de1921d1a1c805a13dc05e44a2cd58f5ad3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
@@ -1595,24 +1940,24 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-24T09:29:48+00:00"
+            "time": "2017-09-06T17:07:39+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "33f87c957122cfbd9d90de48698ee074b71106ea"
+                "reference": "70f5bb3cdd737624249953b61023411e26be5db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/33f87c957122cfbd9d90de48698ee074b71106ea",
-                "reference": "33f87c957122cfbd9d90de48698ee074b71106ea",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/70f5bb3cdd737624249953b61023411e26be5db7",
+                "reference": "70f5bb3cdd737624249953b61023411e26be5db7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "psr/log": "~1.0",
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/event-dispatcher": "~2.8|~3.0",
@@ -1681,20 +2026,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-05T13:28:15+00:00"
+            "time": "2017-09-11T16:13:23+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.4.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937"
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f29dca382a6485c3cbe6379f0c61230167681937",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
                 "shasum": ""
             },
             "require": {
@@ -1706,7 +2051,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -1740,24 +2085,24 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09T14:24:12+00:00"
+            "time": "2017-06-14T15:44:48+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "5ab8949b682b1bf9d4511a228b5e045c96758c30"
+                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/5ab8949b682b1bf9d4511a228b5e045c96758c30",
-                "reference": "5ab8949b682b1bf9d4511a228b5e045c96758c30",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
+                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
@@ -1789,24 +2134,24 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-03T08:12:02+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "dc70bbd0ca7b19259f63cdacc8af370bc32a4728"
+                "reference": "970326dcd04522e1cd1fe128abaee54c225e27f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/dc70bbd0ca7b19259f63cdacc8af370bc32a4728",
-                "reference": "dc70bbd0ca7b19259f63cdacc8af370bc32a4728",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/970326dcd04522e1cd1fe128abaee54c225e27f9",
+                "reference": "970326dcd04522e1cd1fe128abaee54c225e27f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
                 "symfony/config": "<2.8",
@@ -1867,24 +2212,24 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-06-24T09:29:48+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "35dd5fb003c90e8bd4d8cabdf94bf9c96d06fdc3"
+                "reference": "add53753d978f635492dfe8cd6953f6a7361ef90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/35dd5fb003c90e8bd4d8cabdf94bf9c96d06fdc3",
-                "reference": "35dd5fb003c90e8bd4d8cabdf94bf9c96d06fdc3",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/add53753d978f635492dfe8cd6953f6a7361ef90",
+                "reference": "add53753d978f635492dfe8cd6953f6a7361ef90",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -1932,24 +2277,103 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-24T16:45:30+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v3.3.4",
+            "name": "symfony/validator",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9ee920bba1d2ce877496dcafca7cbffff4dbe08a"
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "3ad28ae5f6e71b6c8224569aa6f03908f8a6b1c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9ee920bba1d2ce877496dcafca7cbffff4dbe08a",
-                "reference": "9ee920bba1d2ce877496dcafca7cbffff4dbe08a",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/3ad28ae5f6e71b6c8224569aa6f03908f8a6b1c3",
+                "reference": "3ad28ae5f6e71b6c8224569aa6f03908f8a6b1c3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation": "~2.8|~3.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/dependency-injection": "<3.3",
+                "symfony/yaml": "<3.3"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "egulias/email-validator": "^1.2.8|~2.0",
+                "symfony/cache": "~3.1",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/http-foundation": "~2.8|~3.0",
+                "symfony/intl": "^2.8.18|^3.2.5",
+                "symfony/yaml": "~3.3"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "",
+                "symfony/expression-language": "For using the Expression validator",
+                "symfony/http-foundation": "",
+                "symfony/intl": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Validator Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-08-27T14:52:21+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v3.3.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "89fcb5a73e0ede2be2512234c4e40457bb22b35f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/89fcb5a73e0ede2be2512234c4e40457bb22b35f",
+                "reference": "89fcb5a73e0ede2be2512234c4e40457bb22b35f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -2000,7 +2424,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2017-07-05T13:02:37+00:00"
+            "time": "2017-08-27T14:52:21+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -2048,6 +2472,52 @@
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "time": "2016-09-20T12:50:39+00:00"
+        },
+        {
+            "name": "true/punycode",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/true/php-punycode.git",
+                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/true/php-punycode/zipball/a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
+                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.7",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TrueBV\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Renan Gonçalves",
+                    "email": "renan.saddam@gmail.com"
+                }
+            ],
+            "description": "A Bootstring encoding of Unicode for Internationalized Domain Names in Applications (IDNA)",
+            "homepage": "https://github.com/true/php-punycode",
+            "keywords": [
+                "idna",
+                "punycode"
+            ],
+            "time": "2016-11-16T10:37:54+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -2098,37 +2568,153 @@
                 "environment"
             ],
             "time": "2016-09-01T10:05:43+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2016-09-13T14:38:50+00:00"
+        },
+        {
+            "name": "zendframework/zend-validator",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-validator.git",
+                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
+                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7.6 || ^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.8",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
+                "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
+                "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10-dev",
+                    "dev-develop": "2.11-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a set of commonly needed validators",
+            "homepage": "https://github.com/zendframework/zend-validator",
+            "keywords": [
+                "validator",
+                "zf2"
+            ],
+            "time": "2017-08-22T14:19:23+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -2153,33 +2739,35 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.6.0",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "ext-intl": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
             },
             "type": "library",
             "extra": {
-                "branch-alias": []
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
             },
             "autoload": {
                 "psr-4": {
@@ -2201,7 +2789,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29T12:21:54+00:00"
+            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -2357,16 +2945,16 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -2407,26 +2995,26 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^7.0",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -2452,24 +3040,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-08-30T18:51:59+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -2499,26 +3087,26 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -2529,7 +3117,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -2562,7 +3150,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-09-04T11:05:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2766,29 +3354,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2811,7 +3399,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-08-20T05:47:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -3469,20 +4057,20 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.4",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "1f93a8d19b8241617f5074a123e282575b821df8"
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1f93a8d19b8241617f5074a123e282575b821df8",
-                "reference": "1f93a8d19b8241617f5074a123e282575b821df8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "require-dev": {
                 "symfony/console": "~2.8|~3.0"
@@ -3520,7 +4108,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-15T12:58:50+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/config/radisse.php
+++ b/config/radisse.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Country Code
+    |--------------------------------------------------------------------------
+    |
+    | This is the ISO 3166-1 alpha-2 code of the country where the currency is
+    | used. This information serves several purposes. For example, it’s used
+    | as a default value when providing postal addresses or phone numbers.
+    */
+
+    'country_code' => env('RADISSE_COUNTRY_CODE', 'BE'),
+
+];

--- a/database/migrations/2017_08_13_225927_create_contact_details_table.php
+++ b/database/migrations/2017_08_13_225927_create_contact_details_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateContactDetailsTable extends Migration
+{
+    /**
+     * Create the table of contact details.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('contact_details', function (Blueprint $table) {
+
+            // Primary key.
+            // An unsigned integer with autoincrement.
+            $table->increments('id');
+
+            // Combined foreign key for a polymorphic relationship.
+            // An unsigned integer combined with a string.
+            $table->morphs('contactable');
+
+            // The type of contact info that is stored.
+            $table->string('type');
+
+            // The actual content of the contact info.
+            $table->json('data');
+
+            // Timestamps telling when the table row was created
+            // and when it was modified for the last time.
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Drop the table of contact details.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('contact_details');
+    }
+}

--- a/tests/Unit/ContactDetailsEmailTest.php
+++ b/tests/Unit/ContactDetailsEmailTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Email;
+use Tests\TestCase;
+
+class ContactDetailsEmailTest extends TestCase
+{
+    /** @test */
+    function it_extends_the_contact_details_class()
+    {
+        $email = new Email;
+
+        $this->assertInstanceOf(\App\ContactDetails::class, $email);
+    }
+
+    /** @test */
+    function can_be_constructed_from_an_email_address()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        $this->assertInstanceOf(Email::class, $email);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function it_throws_an_exception_if_the_address_is_invalid()
+    {
+        Email::fromAddress('invalid-email-address');
+    }
+
+    /** @test */
+    function object_exposes_the_address_local_part_as_a_property()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        $this->assertSame('henri', $email->localPart);
+    }
+
+    /** @test */
+    function object_exposes_the_address_domain_as_a_property()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        $this->assertSame('boucheriesanzot.be', $email->domain);
+    }
+
+    /** @test */
+    function object_exposes_address_as_a_property()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        $this->assertSame('henri@boucheriesanzot.be', $email->address);
+    }
+
+    /** @test */
+    function updating_the_local_part_updates_the_whole_address()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        $this->assertSame('henri@boucheriesanzot.be', $email->address);
+
+        // Set a new local part for the e-mail address.
+        $email->localPart = 'info';
+
+        $this->assertSame('info@boucheriesanzot.be', $email->address);
+    }
+
+    /** @test */
+    function updating_the_domain_updates_the_whole_address()
+    {
+        $email = Email::fromAddress('info@boucheriesanzot.be');
+
+        $this->assertSame('info@boucheriesanzot.be', $email->address);
+
+        // Set a new domain for the e-mail address.
+        $email->domain = 'poissonnerieordralfabetix.gaule';
+
+        $this->assertSame('info@poissonnerieordralfabetix.gaule', $email->address);
+    }
+
+    /** @test */
+    function updating_the_address_property_updates_the_local_part_and_the_domain()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        $this->assertSame('henri', $email->localPart);
+        $this->assertSame('boucheriesanzot.be', $email->domain);
+
+        // Set a new e-mail address.
+        $email->address = 'info@poissonnerieordralfabetix.gaule';
+
+        $this->assertSame('info', $email->localPart);
+        $this->assertSame('poissonnerieordralfabetix.gaule', $email->domain);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function updating_the_address_property_with_an_invalid_address_throws_an_exception()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        // Set a new e-mail address.
+        $email->address = 'invalid-email-address';
+    }
+
+    /** @test */
+    function it_is_transformed_to_the_email_address_when_converted_to_a_string()
+    {
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+
+        $this->assertSame('henri@boucheriesanzot.be', $email->__toString());
+        $this->assertSame('henri@boucheriesanzot.be', (string) $email);
+    }
+    /** @test */
+    function it_gathers_the_correct_data_when_saving_the_model_to_the_database()
+    {
+        // Manually trigger database migrations.
+        $this->runDatabaseMigrations();
+
+        // Create and save an Email into the database.
+        $email = Email::fromAddress('henri@boucheriesanzot.be')
+            ->withLabel('Magasin')
+            ->makePublic();
+        // Fake data to satisfy database constraints.
+        $email->contactable_id = 1;
+        $email->contactable_type = 'foo';
+        // Save the model.
+        $email->save();
+
+        $this->assertDatabaseHas('contact_details', [
+            'type' => 'email',
+            'data' => json_encode([
+                'isPublic' => true,
+                'label' => 'Magasin',
+                'address' => 'henri@boucheriesanzot.be',
+            ]),
+        ]);
+    }
+
+    /** @test */
+    function it_fills_its_properties_when_getting_the_model_from_the_database()
+    {
+        // Manually trigger database migrations.
+        $this->runDatabaseMigrations();
+
+        // Create and save an Email model into the database.
+        $email = Email::fromAddress('henri@boucheriesanzot.be')
+            ->withLabel('Magasin')
+            ->makePublic();
+        // Fake data to satisfy database constraints.
+        $email->contactable_id = 1;
+        $email->contactable_type = 'foo';
+        // Save the model.
+        $email->save();
+
+        // Get the model from the database.
+        $email = Email::first();
+
+        $this->assertSame('Magasin', $email->label);
+        $this->assertTrue($email->isPublic);
+        $this->assertSame('henri@boucheriesanzot.be', $email->address);
+    }
+
+    /**
+     * We reimplement this method in order to be able to trigger it manually for
+     * some specific tests instead of having it being automatically triggered
+     * for every test in the file. This allows to make tests run faster.
+     */
+    protected function runDatabaseMigrations()
+    {
+        $this->artisan('migrate');
+
+        $this->app[\Illuminate\Contracts\Console\Kernel::class]->setArtisan(null);
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('migrate:rollback');
+        });
+    }
+}

--- a/tests/Unit/ContactDetailsPhoneTest.php
+++ b/tests/Unit/ContactDetailsPhoneTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Phone;
+use Tests\TestCase;
+
+class ContactDetailsPhoneTest extends TestCase
+{
+    /** @test */
+    function it_extends_the_contact_details_class()
+    {
+        $phone = new Phone;
+
+        $this->assertInstanceOf(\App\ContactDetails::class, $phone);
+    }
+
+    /** @test */
+    function can_be_constructed_from_a_phone_number_string()
+    {
+        $phone = Phone::fromNumber('+32489123456');
+
+        $this->assertInstanceOf(Phone::class, $phone);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function the_phone_number_must_be_valid()
+    {
+        Phone::fromNumber('invalid-phone-number');
+    }
+
+    /** @test */
+    function object_exposes_the_number_as_a_property()
+    {
+        $phone = Phone::fromNumber('+32489123456');
+
+        $this->assertTrue(property_exists($phone, 'number'));
+    }
+
+    /** @test */
+    function updating_the_number_property_formats_it_in_international_format()
+    {
+        $phone = Phone::fromNumber('0489 12 34 56');
+
+        $this->assertSame('+32 489 12 34 56', $phone->number);
+
+        // Set a new number.
+        $phone->number = '0489 65 43 21';
+
+        $this->assertSame('+32 489 65 43 21', $phone->number);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function updating_the_number_property_with_an_invalid_number_throws_an_exception()
+    {
+        $phone = Phone::fromNumber('+32489123456');
+
+        // Set a new number.
+        $phone->number = 'invalid-phone-number';
+    }
+
+    /** @test */
+    function can_format_number_in_national_format()
+    {
+        $phone = Phone::fromNumber('+32489123456');
+
+        $this->assertSame('0489 12 34 56', $phone->toNationalFormat());
+    }
+
+    /** @test */
+    function can_format_number_in_international_format()
+    {
+        $phone = Phone::fromNumber('+32489123456');
+
+        $this->assertSame('+32 489 12 34 56', $phone->toInternationalFormat());
+    }
+
+    /** @test */
+    function can_format_number_in_E164_format()
+    {
+        $phone = Phone::fromNumber('+32 489 12 34 56');
+
+        $this->assertSame('+32489123456', $phone->toE164Format());
+    }
+
+    /** @test */
+    function it_is_formatted_in_international_format_when_converted_to_a_string()
+    {
+        $phone = Phone::fromNumber('+32489123456');
+
+        $this->assertSame('+32 489 12 34 56', $phone->__toString());
+        $this->assertSame('+32 489 12 34 56', (string) $phone);
+    }
+
+    /** @test */
+    function it_fills_its_properties_when_getting_the_model_from_the_database()
+    {
+        // Manually trigger database migrations.
+        $this->runDatabaseMigrations();
+
+        // Create and save a Phone model into the database.
+        $phone = Phone::fromNumber('+32489123456')
+            ->withLabel('Magasin')
+            ->makePublic();
+        // Fake data to satisfy database constraints.
+        $phone->contactable_id = 1;
+        $phone->contactable_type = 'foo';
+        // Save the model.
+        $phone->save();
+
+        // Get the model from the database.
+        $phone = Phone::first();
+
+        $this->assertSame('Magasin', $phone->label);
+        $this->assertTrue($phone->isPublic);
+        $this->assertSame('+32489123456', $phone->number);
+    }
+
+    /**
+     * We reimplement this method in order to be able to trigger it manually for
+     * some specific tests instead of having it being automatically triggered
+     * for every test in the file. This allows to make tests run faster.
+     */
+    protected function runDatabaseMigrations()
+    {
+        $this->artisan('migrate');
+
+        $this->app[\Illuminate\Contracts\Console\Kernel::class]->setArtisan(null);
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('migrate:rollback');
+        });
+    }
+}

--- a/tests/Unit/ContactDetailsPostalAddressTest.php
+++ b/tests/Unit/ContactDetailsPostalAddressTest.php
@@ -155,6 +155,22 @@ class ContactDetailsPostalAddressTest extends TestCase
     }
 
     /** @test */
+    function it_handles_the_letter_box_number_when_formatting_the_address()
+    {
+        $address = $this->makeTestAddress(['letter_box' => '5']);
+
+        $this->assertSame(
+            "Boucherie Sanzot\n".
+            // The letter box number is added to this line.
+            // /!\ This is specific to Belgian postal services /!\
+            "rue du Château 1 bte 5\n".
+            "1234 Moulinsart\n".
+            "Belgique",
+            $address->__toString()
+        );
+    }
+
+    /** @test */
     function it_gathers_the_correct_data_when_saving_the_model_to_the_database()
     {
         // Manually trigger database migrations.

--- a/tests/Unit/ContactDetailsPostalAddressTest.php
+++ b/tests/Unit/ContactDetailsPostalAddressTest.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\PostalAddress;
+
+class ContactDetailsPostalAddressTest extends TestCase
+{
+    // Modifier les tests
+    // Tous les désactiver
+    // Les réactiver un par un pour guider l’implémentation
+    // Idéalement, ne rien implémenter sans avoir de test qui couvre ce code
+
+    /** @test */
+    function it_extends_the_contact_details_class()
+    {
+        $address = new PostalAddress;
+
+        $this->assertInstanceOf(\App\ContactDetails::class, $address);
+    }
+
+    /** @test */
+    function can_be_constructed_from_an_array()
+    {
+        $address = PostalAddress::fromArray([
+            'recipient' => 'Boucherie Sanzot',
+            'street' => 'rue du Château',
+            'street_number' => '1',
+            'letter_box' => null,
+            'postal_code' => '1234',
+            'city' => 'Moulinsart',
+            'latitude' => null,
+            'longitude' => null,
+        ]);
+
+        $this->assertInstanceOf(PostalAddress::class, $address);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function it_throws_an_exception_if_a_required_address_component_is_missing()
+    {
+        // We try to create an address with no info except a street name.
+        // This is obviously not enough to have a valid address.
+        PostalAddress::fromArray(['street' => 'rue du Château']);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function it_throws_an_exception_if_the_postal_code_looks_invalid()
+    {
+        $this->makeTestAddress(['postal_code' => 'invalid-postal-code']);
+    }
+
+    /** @test */
+    function object_exposes_the_recipient_as_a_property()
+    {
+        $address = $this->makeTestAddress(['recipient' => 'Boucherie Sanzot']);
+
+        $this->assertSame('Boucherie Sanzot', $address->recipient);
+    }
+
+    /** @test */
+    function object_exposes_the_street_name_as_a_property()
+    {
+        $address = $this->makeTestAddress(['street' => 'rue du Château']);
+
+        $this->assertSame('rue du Château', $address->street);
+    }
+
+    /** @test */
+    function object_exposes_the_street_number_as_a_property()
+    {
+        $address = $this->makeTestAddress(['street_number' => '1']);
+
+        $this->assertSame('1', $address->streetNumber);
+    }
+
+    /** @test */
+    function object_exposes_the_letter_box_number_as_a_property()
+    {
+        $address = $this->makeTestAddress(['letter_box' => '5']);
+
+        $this->assertSame('5', $address->letterBox);
+    }
+
+    /** @test */
+    function object_exposes_the_postal_code_as_a_property()
+    {
+        $address = $this->makeTestAddress(['postal_code' => '1234']);
+
+        $this->assertSame('1234', $address->postalCode);
+    }
+
+    /** @test */
+    function object_exposes_the_city_as_a_property()
+    {
+        $address = $this->makeTestAddress(['city' => 'Moulinsart']);
+
+        $this->assertSame('Moulinsart', $address->city);
+    }
+
+    /** @test */
+    function object_exposes_the_latitude_as_a_property()
+    {
+        $address = $this->makeTestAddress(['latitude' => 50.671155]);
+
+        $this->assertSame(50.671155, $address->latitude);
+    }
+
+    /** @test */
+    function object_exposes_the_longitude_as_a_property()
+    {
+        $address = $this->makeTestAddress(['longitude' => 4.612869]);
+
+        $this->assertSame(4.612869, $address->longitude);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function updating_an_address_component_with_an_invalid_value_throws_an_exception()
+    {
+        $address = $this->makeTestAddress();
+
+        // Set a new, invalid postal code.
+        $address->postalCode = 'invalid-postal-code';
+    }
+
+    /** @test */
+    function it_is_transformed_to_the_postal_address_when_converted_to_a_string()
+    {
+        $address = $this->makeTestAddress();
+
+        $this->assertSame(
+            "Boucherie Sanzot\n".
+            "rue du Château 1\n".
+            "1234 Moulinsart\n".
+            "Belgique",
+            $address->__toString()
+        );
+        $this->assertSame(
+            "Boucherie Sanzot\n".
+            "rue du Château 1\n".
+            "1234 Moulinsart\n".
+            "Belgique",
+            (string) $address
+        );
+    }
+
+    /** @test */
+    function it_gathers_the_correct_data_when_saving_the_model_to_the_database()
+    {
+        // Manually trigger database migrations.
+        $this->runDatabaseMigrations();
+
+        // Create and save a PostalAddress into the database.
+        $address = $this->makeTestAddress()->withLabel('Magasin')->makePublic();
+        // Fake data to satisfy database constraints.
+        $address->contactable_id = 1;
+        $address->contactable_type = 'foo';
+        // Save the model.
+        $address->save();
+
+        $this->assertDatabaseHas('contact_details', [
+            'type' => 'postal-address',
+            'data' => json_encode([
+                'isPublic' => true,
+                'label' => 'Magasin',
+                'parts' => [
+                    'recipient' => 'Boucherie Sanzot',
+                    'street' => 'rue du Château',
+                    'street_number' => '1',
+                    'letter_box' => null,
+                    'postal_code' => '1234',
+                    'city' => 'Moulinsart',
+                    'latitude' => 50.671155,
+                    'longitude' => 4.612869,
+                ],
+            ]),
+        ]);
+    }
+
+    /** @test */
+    function it_fills_its_properties_when_getting_the_model_from_the_database()
+    {
+        // Manually trigger database migrations.
+        $this->runDatabaseMigrations();
+
+        // Create and save a PostalAddress model into the database.
+        $address = $this->makeTestAddress()->withLabel('Magasin')->makePublic();
+        // Fake data to satisfy database constraints.
+        $address->contactable_id = 1;
+        $address->contactable_type = 'foo';
+        // Save the model.
+        $address->save();
+
+        // Get the model from the database.
+        $address = PostalAddress::first();
+
+        $this->assertSame('Magasin', $address->label);
+        $this->assertTrue($address->isPublic);
+        $this->assertSame('Boucherie Sanzot', $address->recipient);
+        $this->assertSame('rue du Château', $address->street);
+        $this->assertSame('1', $address->streetNumber);
+        $this->assertSame(null, $address->letterBox);
+        $this->assertSame('1234', $address->postalCode);
+        $this->assertSame('Moulinsart', $address->city);
+        $this->assertSame(50.671155, $address->latitude);
+        $this->assertSame(4.612869, $address->longitude);
+    }
+
+    /**
+     * Helper method to avoid redundancy in tests.
+     *
+     * @param  array  $overwrite  An array of address components that should
+     *                            overwrite the default values.
+     *
+     * @return \App\PostalAddress
+     */
+    protected function makeTestAddress(array $overwrite = [])
+    {
+        $addressParts = [
+            'recipient' => 'Boucherie Sanzot',
+            'street' => 'rue du Château',
+            'street_number' => '1',
+            'letter_box' => null,
+            'postal_code' => '1234',
+            'city' => 'Moulinsart',
+            'latitude' => 50.671155,
+            'longitude' => 4.612869,
+        ];
+
+        return PostalAddress::fromArray($overwrite + $addressParts);
+    }
+
+    /**
+     * We reimplement this method in order to be able to trigger it manually for
+     * some specific tests instead of having it being automatically triggered
+     * for every test in the file. This allows to make tests run faster.
+     */
+    protected function runDatabaseMigrations()
+    {
+        $this->artisan('migrate');
+
+        $this->app[\Illuminate\Contracts\Console\Kernel::class]->setArtisan(null);
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('migrate:rollback');
+        });
+    }
+}

--- a/tests/Unit/ContactDetailsSocialNetworkTest.php
+++ b/tests/Unit/ContactDetailsSocialNetworkTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\SocialNetwork;
+
+class ContactDetailsSocialNetworkTest extends TestCase
+{
+    /** @test */
+    function it_extends_the_contact_details_class()
+    {
+        $network = new SocialNetwork;
+
+        $this->assertInstanceOf(\App\ContactDetails::class, $network);
+    }
+
+    /** @test */
+    function can_be_constructed_from_a_url()
+    {
+        $network = SocialNetwork::fromUrl('https://www.facebook.com/boucheriesanzot');
+
+        $this->assertInstanceOf(SocialNetwork::class, $network);
+    }
+
+    /** @test */
+    function object_exposes_the_network_name_in_lowercase_as_a_property()
+    {
+        $network = SocialNetwork::fromUrl('https://www.facebook.com/boucheriesanzot');
+
+        $this->assertSame('facebook', $network->name);
+        $this->assertNotSame('Facebook', $network->name);
+    }
+
+    /** @test */
+    function object_exposes_the_network_handle_as_a_property()
+    {
+        $network = SocialNetwork::fromUrl('https://www.facebook.com/boucheriesanzot');
+
+        $this->assertSame('boucheriesanzot', $network->handle);
+    }
+
+    /**
+     * @test
+     * @dataProvider facebookAddressProvider
+     */
+    function it_supports_the_facebook_social_network($url)
+    {
+        // If we get no exception, then everything’s fine.
+        SocialNetwork::fromUrl($url);
+    }
+
+    /** @test */
+    function it_detects_facebook_handles()
+    {
+        $network = SocialNetwork::fromUrl('facebook.com/boucheriesanzot');
+        $this->assertSame('boucheriesanzot', $network->handle);
+
+        $network = SocialNetwork::fromUrl('facebook.com/boucherie-sanzot');
+        $this->assertSame('boucherie-sanzot', $network->handle);
+
+        $network = SocialNetwork::fromUrl('facebook.com/boucherie.sanzot');
+        $this->assertSame('boucherie.sanzot', $network->handle);
+
+        $network = SocialNetwork::fromUrl('facebook.com/boucherie.sanzot-12345');
+        $this->assertSame('boucherie.sanzot-12345', $network->handle);
+    }
+
+    /**
+     * @test
+     * @dataProvider twitterAddressProvider
+     */
+    function it_supports_the_twitter_social_network($url)
+    {
+        // If we get no exception, then everything’s fine.
+        SocialNetwork::fromUrl($url);
+    }
+
+    /** @test */
+    function it_detects_twitter_handles()
+    {
+        $network = SocialNetwork::fromUrl('facebook.com/boucheriesanzot');
+        $this->assertSame('boucheriesanzot', $network->handle);
+
+        $network = SocialNetwork::fromUrl('facebook.com/boucherie-sanzot');
+        $this->assertSame('boucherie-sanzot', $network->handle);
+
+        $network = SocialNetwork::fromUrl('facebook.com/boucherie.sanzot');
+        $this->assertSame('boucherie.sanzot', $network->handle);
+
+        $network = SocialNetwork::fromUrl('facebook.com/boucherie.sanzot-12345');
+        $this->assertSame('boucherie.sanzot-12345', $network->handle);
+    }
+
+    /**
+     * @test
+     * @expectedException DomainException
+     */
+    function it_throws_an_exception_if_the_social_network_cannot_be_recognized()
+    {
+        SocialNetwork::fromUrl('invalid-social-network-url');
+    }
+
+    /** @test */
+    function object_exposes_url_as_a_property()
+    {
+        $network = SocialNetwork::fromUrl('facebook.com/boucheriesanzot');
+
+        $this->assertInternalType('string', $network->url);
+        $this->assertSame('https://www.facebook.com/boucheriesanzot', $network->url);
+    }
+
+    /** @test */
+    function it_is_transformed_to_the_url_when_converted_to_a_string()
+    {
+        $network = SocialNetwork::fromUrl('facebook.com/boucheriesanzot');
+
+        $this->assertSame(
+            'https://www.facebook.com/boucheriesanzot',
+            $network->__toString()
+        );
+        $this->assertSame(
+            'https://www.facebook.com/boucheriesanzot',
+            (string) $network
+        );
+    }
+
+    /** @test */
+    function it_gathers_the_correct_data_when_saving_the_model_to_the_database()
+    {
+        // Manually trigger database migrations.
+        $this->runDatabaseMigrations();
+
+        // Create and save a SocialNetwork model into the database.
+        $network = SocialNetwork::fromUrl('https://www.facebook.com/boucheriesanzot')
+            ->withLabel('Page Facebook')
+            ->makePublic();
+        // Fake data to satisfy database constraints.
+        $network->contactable_id = 1;
+        $network->contactable_type = 'foo';
+        // Save the model.
+        $network->save();
+
+        $this->assertDatabaseHas('contact_details', [
+            'type' => 'social-network',
+            'data' => json_encode([
+                'isPublic' => true,
+                'label' => 'Page Facebook',
+                'name' => 'facebook',
+                'handle' => 'boucheriesanzot',
+            ]),
+        ]);
+    }
+
+    /** @test */
+    function it_fills_its_properties_when_getting_the_model_from_the_database()
+    {
+        // Manually trigger database migrations.
+        $this->runDatabaseMigrations();
+
+        // Create and save a SocialNetwork model into the database.
+        $network = SocialNetwork::fromUrl('https://www.facebook.com/boucheriesanzot')
+            ->withLabel('Page Facebook')
+            ->makePublic();
+        // Fake data to satisfy database constraints.
+        $network->contactable_id = 1;
+        $network->contactable_type = 'foo';
+        // Save the model.
+        $network->save();
+
+        // Get the model from the database.
+        $network = SocialNetwork::first();
+
+        $this->assertSame('Page Facebook', $network->label);
+        $this->assertTrue($network->isPublic);
+        $this->assertSame('https://www.facebook.com/boucheriesanzot', $network->url);
+    }
+
+    /**
+     * We reimplement this method in order to be able to trigger it manually for
+     * some specific tests instead of having it being automatically triggered
+     * for every test in the file. This allows to make tests run faster.
+     */
+    protected function runDatabaseMigrations()
+    {
+        $this->artisan('migrate');
+
+        $this->app[\Illuminate\Contracts\Console\Kernel::class]->setArtisan(null);
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('migrate:rollback');
+        });
+    }
+
+    /**
+     * Provides a series of URLs for the Facebook social network.
+     *
+     * @return array
+     */
+    function facebookAddressProvider()
+    {
+        return [
+            ['facebook.com/boucheriesanzot'],
+            ['www.facebook.com/boucheriesanzot'],
+            ['http://facebook.com/boucheriesanzot'],
+            ['http://www.facebook.com/boucheriesanzot'],
+            ['https://facebook.com/boucheriesanzot'],
+            ['https://www.facebook.com/boucheriesanzot'],
+        ];
+    }
+
+    /**
+     * Provides a series of URLs for the Twitter social network.
+     *
+     * @return array
+     */
+    function twitterAddressProvider()
+    {
+        return [
+            ['twitter.com/boucheriesanzot'],
+            ['www.twitter.com/boucheriesanzot'],
+            ['http://twitter.com/boucheriesanzot'],
+            ['http://www.twitter.com/boucheriesanzot'],
+            ['https://twitter.com/boucheriesanzot'],
+            ['https://www.twitter.com/boucheriesanzot'],
+        ];
+    }
+}

--- a/tests/Unit/ContactDetailsTest.php
+++ b/tests/Unit/ContactDetailsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\ContactDetails;
+
+class ContactDetailsTest extends TestCase
+{
+    /** @test */
+    function object_exposes_a_read_only_type_property()
+    {
+        $contactInfo = new ContactDetails;
+
+        $this->assertTrue(property_exists($contactInfo, 'type'));
+
+        // Artifically set a value to the property.
+        $reflectionClass = new \ReflectionClass($contactInfo);
+        $property = $reflectionClass->getProperty('type');
+        $property->setAccessible(true);
+        $property->setValue($contactInfo, 'foo');
+
+        // Check that the value was properly set.
+        $this->assertSame('foo', $contactInfo->type);
+
+        // Try to change the value of the property.
+        $this->type = 'bar';
+
+        // Test that it did not change and that it still has the previous value.
+        $this->assertSame('foo', $contactInfo->type);
+    }
+
+    /** @test */
+    function object_exposes_a_property_telling_if_the_stored_info_is_public()
+    {
+        $contactInfo = new ContactDetails;
+
+        $this->assertTrue(property_exists($contactInfo, 'isPublic'));
+
+        $contactInfo->isPublic = false;
+
+        // Check just to be sure that the value was properly set.
+        $this->assertFalse($contactInfo->isPublic);
+
+        $contactInfo->isPublic = true;
+
+        $this->assertTrue($contactInfo->isPublic);
+
+        // Test the `isPrivate` counterpart.
+        $contactInfo->isPrivate = true;
+
+        $this->assertTrue($contactInfo->isPrivate);
+        // Make sure that updating `isPrivate` changed the value of `isPublic`.
+        $this->assertFalse($contactInfo->isPublic);
+    }
+
+    /** @test */
+    function the_stored_info_is_private_by_default()
+    {
+        $contactInfo = new ContactDetails;
+
+        $this->assertFalse($contactInfo->isPublic);
+        $this->assertTrue($contactInfo->isPrivate);
+    }
+
+    /** @test */
+    function the_public_state_of_the_stored_info_can_be_changed_using_a_method()
+    {
+        $contactInfo = new ContactDetails;
+        $contactInfo->isPublic = false;
+
+        $contactInfo->makePublic();
+
+        $this->assertTrue($contactInfo->isPublic);
+
+        // Test the `makePrivate()` counterpart.
+        $contactInfo->makePrivate();
+
+        $this->assertTrue($contactInfo->isPrivate);
+        $this->assertFalse($contactInfo->isPublic);
+    }
+
+    /** @test */
+    function object_exposes_label_as_a_property()
+    {
+        $contactInfo = new ContactDetails;
+
+        $this->assertTrue(property_exists($contactInfo, 'label'));
+    }
+
+    /** @test */
+    function a_label_can_be_added_to_an_existing_contact_info_using_a_property()
+    {
+        $contactInfo = new ContactDetails;
+
+        $this->assertNull($contactInfo->label);
+
+        $contactInfo->label = 'An awesome label';
+
+        $this->assertSame('An awesome label', $contactInfo->label);
+    }
+
+    /** @test */
+    function a_label_can_be_added_to_an_existing_contact_info_using_a_method()
+    {
+        $contactInfo = new ContactDetails;
+
+        $this->assertNull($contactInfo->label);
+
+        $contactInfo->withLabel('An awesome label');
+
+        $this->assertSame('An awesome label', $contactInfo->label);
+    }
+
+    /** @test */
+    function a_label_can_be_removed_from_an_existing_contact_info()
+    {
+        $contactInfo = new ContactDetails;
+        $contactInfo->label = 'An awesome label';
+
+        $this->assertSame('An awesome label', $contactInfo->label);
+
+        // Setting the label to an empty string should make it null.
+        $contactInfo->label = '';
+
+        $this->assertNull($contactInfo->label);
+
+        // Of course, explicitly setting it to null will keep it null.
+        $contactInfo->label = null;
+
+        $this->assertNull($contactInfo->label);
+    }
+}

--- a/tests/Unit/PartnerTest.php
+++ b/tests/Unit/PartnerTest.php
@@ -2,9 +2,13 @@
 
 namespace Tests\Unit\Admin;
 
+use App\Email;
+use App\Phone;
 use App\Partner;
 use App\Location;
 use Tests\TestCase;
+use App\PostalAddress;
+use App\SocialNetwork;
 use App\PartnerRepresentative;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -104,5 +108,56 @@ class PartnerTest extends TestCase
         $this->assertSame($personB->id, $representatives[1]->id);
         $this->assertSame('Iélosubmarine', $representatives[1]->given_name);
         $this->assertSame('gérante', $representatives[1]->role);
+    }
+
+    /** @test */
+    function can_retrieve_its_contact_details()
+    {
+        $partner = factory(Partner::class)->create([
+            'name' => 'Boucherie Sanzot',
+        ]);
+
+        // Create different types of contact details.
+        $address = PostalAddress::fromArray([
+            'recipient' => 'Boucherie Sanzot',
+            'street' => 'rue du Château',
+            'street_number' => '1',
+            'letter_box' => null,
+            'postal_code' => '1234',
+            'city' => 'Moulinsart',
+            'latitude' => null,
+            'longitude' => null,
+        ]);
+        $phone = Phone::fromNumber('+32489123456');
+        $email = Email::fromAddress('henri@boucheriesanzot.be');
+        $network = SocialNetwork::fromUrl('https://www.facebook.com/boucheriesanzot');
+
+        // Save the contact details.
+        $partner->postalAddresses()->save($address);
+        $partner->phones()->save($phone);
+        $partner->emails()->save($email);
+        $partner->socialNetworks()->save($network);
+
+        // Finally, we test that we can properly get everything back.
+
+        // Postal addresses.
+        $this->assertCount(1, $partner->postalAddresses);
+        $this->assertInstanceOf(PostalAddress::class, $partner->postalAddresses[0]);
+        $this->assertSame($address->id, $partner->postalAddresses[0]->id);
+
+        // Phone numbers.
+        $this->assertCount(1, $partner->phones);
+        $this->assertInstanceOf(Phone::class, $partner->phones[0]);
+        $this->assertSame($phone->id, $partner->phones[0]->id);
+
+        // E-mail addresses.
+        $this->assertCount(1, $partner->emails);
+        $this->assertInstanceOf(Email::class, $partner->emails[0]);
+        $this->assertSame($email->id, $partner->emails[0]->id);
+
+        // Social networks.
+        $this->assertCount(1, $partner->socialNetworks);
+        $this->assertInstanceOf(SocialNetwork::class, $partner->socialNetworks[0]);
+        $this->assertSame($network->id, $partner->socialNetworks[0]->id);
     }
 }


### PR DESCRIPTION
This enables partners to have contact details. Those are implemented as subclasses of a main `ContactDetails` class, and these subclasses serve both as entities and Eloquent models. They are linked to partners using polymorphic relationships.

Four types of contact details are available. All of them expose both common and specific properties. These four types are:
- postal addresses
- phone numbers
- e-mail addresses
- social networks

Contact details are currently linked to partners only. In the future, they might also be used for locations, team members or other types of models.