### PR TITLE
Refactor and work on contact details

### DIFF
--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -16,18 +16,17 @@ class PartnerRepresentative extends Model
     use HasPhones;
 
     /**
-     * Set the partner representative’s email.
+     * Associate an email address with the partner representative.
      *
-     * @param  string  $email
-     * @return void
+     * @param string  $address
+     * @param bool    $isPublic
      */
-    public function setEmailAttribute($email)
+    public function addEmail($address, $isPublic = false)
     {
-        if (!is_null($email) && filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
-            throw new DomainException("[{$email}] is an invalid e-mail address.");
-        }
+        $email = Email::fromAddress($address);
+        $email->isPublic = (bool) $isPublic;
 
-        $this->attributes['email'] = $email;
+        $this->emails()->save($email);
     }
 
     /**
@@ -71,7 +70,7 @@ class PartnerRepresentative extends Model
      */
     public function hasEmail()
     {
-        return !is_null($this->email);
+        return $this->emails->isNotEmpty();
     }
 
     /**

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -40,27 +40,17 @@ class PartnerRepresentative extends Model
     }
 
     /**
-     * Set the partner representative’s phone number.
+     * Associate a phone number with the partner representative.
      *
-     * @param  string  $phone
-     * @return void
+     * @param string  $number
+     * @param bool    $isPublic
      */
-    public function setPhoneAttribute($phone)
+    public function addPhone($number, $isPublic = false)
     {
-        // If a phone number has been provided, we check if it is valid.
-        // If it is, we then format it in the E.164 format.
-        // @see https://en.wikipedia.org/wiki/E.164
-        if (!is_null($phone)) {
+        $phone = Phone::fromNumber($number);
+        $phone->isPublic = (bool) $isPublic;
 
-            if (validator([$phone], ['phone:BE'])->fails()) {
-                throw new DomainException("[{$phone}] is an invalid phone number.");
-            }
-
-            // The number seems valid. Format it in a standard way.
-            $phone = phone($phone, 'BE')->formatE164();
-        }
-
-        $this->attributes['phone'] = $phone;
+        $this->phones()->save($phone);
     }
 
     /**
@@ -90,6 +80,6 @@ class PartnerRepresentative extends Model
      */
     public function hasPhone()
     {
-        return !is_null($this->phone);
+        return $this->phones->isNotEmpty();
     }
 }

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -54,6 +54,16 @@ class PartnerRepresentative extends Model
     }
 
     /**
+     * Associate a public phone number with the partner representative.
+     *
+     * @param string  $number
+     */
+    public function addPublicPhone($number)
+    {
+        $this->addPhone($number, $isPublic = true);
+    }
+
+    /**
      * Get the partner that this person represents.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/PartnerRepresentative.php
+++ b/app/PartnerRepresentative.php
@@ -30,6 +30,16 @@ class PartnerRepresentative extends Model
     }
 
     /**
+     * Associate a public email address with the partner representative.
+     *
+     * @param string  $address
+     */
+    public function addPublicEmail($address)
+    {
+        $this->addEmail($address, $isPublic = true);
+    }
+
+    /**
      * Set the partner representative’s phone number.
      *
      * @param  string  $phone

--- a/app/PostalAddress.php
+++ b/app/PostalAddress.php
@@ -242,6 +242,13 @@ class PostalAddress extends ContactDetails
         }
     }
 
+    public function toHtml()
+    {
+        $address = $this->toAddressObject();
+
+        return $this->getFormatter($asHtml = true)->format($address);
+    }
+
     /**
      * Convert the address to its string representation.
      *
@@ -259,14 +266,18 @@ class PostalAddress extends ContactDetails
      *
      * @return \CommerceGuys\Addressing\Formatter\DefaultFormatter
      */
-    protected function getFormatter()
+    protected function getFormatter($asHtml = false)
     {
         return new DefaultFormatter(
             new AddressFormatRepository,
             new CountryRepository,
             new SubdivisionRepository,
             $locale = config('app.locale'),
-            $options = ['html' => false]
+            $options = [
+                'html' => $asHtml,
+                'html_tag' => 'p',
+                'html_attributes' => ['translate' => 'no'],
+            ]
         );
     }
 }

--- a/tests/Unit/ContactDetailsPostalAddressTest.php
+++ b/tests/Unit/ContactDetailsPostalAddressTest.php
@@ -134,6 +134,23 @@ class ContactDetailsPostalAddressTest extends TestCase
     }
 
     /** @test */
+    function it_can_format_the_postal_address_in_an_html_format()
+    {
+        $address = $this->makeTestAddress();
+
+        $this->assertSame(
+            '<p translate="no">'."\n".
+            '<span class="recipient">Boucherie Sanzot</span><br>'."\n".
+            '<span class="address-line1">rue du Château 1</span><br>'."\n".
+            '<span class="postal-code">1234</span> '.
+            '<span class="locality">Moulinsart</span><br>'."\n".
+            '<span class="country">Belgique</span>'."\n".
+            '</p>',
+            $address->toHtml()
+        );
+    }
+
+    /** @test */
     function it_is_transformed_to_the_postal_address_when_converted_to_a_string()
     {
         $address = $this->makeTestAddress();

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -74,6 +74,19 @@ class PartnerRepresentativeTest extends TestCase
         $this->assertFalse($representativeB->hasPhone());
     }
 
+    /** @test */
+    function can_be_associated_with_an_optional_phone_number_that_is_public()
+    {
+        $representativeA = factory(PartnerRepresentative::class)->create();
+        $representativeA->addPublicPhone('+32489123456');
+
+        $representativeB = factory(PartnerRepresentative::class)->create();
+        $representativeB->addPhone('+32489654321');
+
+        $this->assertTrue($representativeA->phones->first()->isPublic);
+        $this->assertFalse($representativeB->phones->first()->isPublic);
+    }
+
     /**
      * @test
      * @expectedException DomainException

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -38,6 +38,19 @@ class PartnerRepresentativeTest extends TestCase
         $this->assertFalse($representativeB->hasEmail());
     }
 
+    /** @test */
+    function can_be_associated_with_an_optional_email_address_that_is_public()
+    {
+        $representativeA = factory(PartnerRepresentative::class)->create();
+        $representativeA->addPublicEmail('contact@boucheriesanzot.be');
+
+        $representativeB = factory(PartnerRepresentative::class)->create();
+        $representativeB->addEmail('henri@boucheriesanzot.be');
+
+        $this->assertTrue($representativeA->emails->first()->isPublic);
+        $this->assertFalse($representativeB->emails->first()->isPublic);
+    }
+
     /**
      * @test
      * @expectedException DomainException

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -27,14 +27,12 @@ class PartnerRepresentativeTest extends TestCase
     }
 
     /** @test */
-    function can_have_an_optional_email_address()
+    function can_be_associated_with_an_optional_email_address()
     {
-        $representativeA = factory(PartnerRepresentative::class)->make([
-            'email' => 'henri@boucheriesanzot.be',
-        ]);
-        $representativeB = factory(PartnerRepresentative::class)->make([
-            'email' => null,
-        ]);
+        $representativeA = factory(PartnerRepresentative::class)->create();
+        $representativeA->addEmail('henri@boucheriesanzot.be');
+
+        $representativeB = factory(PartnerRepresentative::class)->create();
 
         $this->assertTrue($representativeA->hasEmail());
         $this->assertFalse($representativeB->hasEmail());
@@ -46,9 +44,9 @@ class PartnerRepresentativeTest extends TestCase
      */
     function the_email_address_must_be_valid()
     {
-        $representative = factory(PartnerRepresentative::class)->make([
-            'email' => 'invalid-email-address',
-        ]);
+        $representative = factory(PartnerRepresentative::class)->make();
+
+        $representative->addEmail('invalid-email-address');
     }
 
     /** @test */

--- a/tests/Unit/PartnerRepresentativeTest.php
+++ b/tests/Unit/PartnerRepresentativeTest.php
@@ -63,14 +63,12 @@ class PartnerRepresentativeTest extends TestCase
     }
 
     /** @test */
-    function can_have_an_optional_phone_number()
+    function can_be_associated_with_an_optional_phone_number()
     {
-        $representativeA = factory(PartnerRepresentative::class)->make([
-            'phone' => '+32489123456',
-        ]);
-        $representativeB = factory(PartnerRepresentative::class)->make([
-            'phone' => null,
-        ]);
+        $representativeA = factory(PartnerRepresentative::class)->create();
+        $representativeA->addPhone('+32489123456');
+
+        $representativeB = factory(PartnerRepresentative::class)->create();
 
         $this->assertTrue($representativeA->hasPhone());
         $this->assertFalse($representativeB->hasPhone());
@@ -82,31 +80,35 @@ class PartnerRepresentativeTest extends TestCase
      */
     function the_phone_number_must_be_valid()
     {
-        factory(PartnerRepresentative::class)->make(['phone' => 'invalid']);
+        $representative = factory(PartnerRepresentative::class)->make();
+
+        $representative->addPhone('invalid');
     }
 
     /** @test */
     function the_phone_number_can_be_provided_in_multiple_formats()
     {
+        $representative = factory(PartnerRepresentative::class)->create();
+
         // International format (E.164).
-        factory(PartnerRepresentative::class)->make(['phone' => '+32489123456']);
+        $representative->addPhone('+32489123456');
 
         // National format, without spaces.
-        factory(PartnerRepresentative::class)->make(['phone' => '0489123456']);
+        $representative->addPhone('0489123456');
 
         // National format, with spaces.
-        factory(PartnerRepresentative::class)->make(['phone' => '0489 12 34 56']);
-        factory(PartnerRepresentative::class)->make(['phone' => '0489 123 456']);
+        $representative->addPhone('0489 12 34 56');
+        $representative->addPhone('0489 123 456');
 
         // Without leading zero.
-        factory(PartnerRepresentative::class)->make(['phone' => '489 12 34 56']);
-        factory(PartnerRepresentative::class)->make(['phone' => '489 123 456']);
+        $representative->addPhone('489 12 34 56');
+        $representative->addPhone('489 123 456');
 
         // With slash and dots.
-        factory(PartnerRepresentative::class)->make(['phone' => '0489/12.34.56']);
+        $representative->addPhone('0489/12.34.56');
 
         // Totally drunk…
-        factory(PartnerRepresentative::class)->make(['phone' => '+32 (0) 48 9 123 4 56']);
+        $representative->addPhone('+32 (0) 48 9 123 4 56');
 
         // If we got no exception until here, then everything is fine.
         // This is a workaround for the lack of an annotation that


### PR DESCRIPTION
This brings some refactoring to get rid of old code that was still relying on attribute mutators for some contact details (instead of using the dedicated classes that are now available).

This also add a few helper methods that mostly replace the old functionality in a different way.