### PR TITLE
Tweak routing for teaser page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -2,8 +2,12 @@
 
 Route::view('/', 'public.home');
 
-// If we haven’t launched yet, redirect home to a teaser page.
-if (\Carbon\Carbon::now()->lessThan(\Carbon\Carbon::parse('next Saturday 18:00'))) {
+// If we haven’t launched yet (and are not in a local
+// environment), redirect home to a teaser page.
+if (
+    \Carbon\Carbon::now()->lessThan(\Carbon\Carbon::parse('next Saturday 18:00')) &&
+    config('app.env') !== 'local'
+) {
     Route::view('/', 'public.launch-teaser');
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,10 +2,9 @@
 
 Route::view('/', 'public.home');
 
-// If we haven’t launched yet, add a temporary redirect to a teaser page.
-if (\Carbon\Carbon::now() < \Carbon\Carbon::parse('next Saturday 18:00')) {
-    Route::view('/bientot', 'public.launch-teaser');
-    Route::redirect('/', '/bientot', 307);
+// If we haven’t launched yet, redirect home to a teaser page.
+if (\Carbon\Carbon::now()->lessThan(\Carbon\Carbon::parse('next Saturday 18:00'))) {
+    Route::view('/', 'public.launch-teaser');
 }
 
 


### PR DESCRIPTION
Overwriting a routing definition is better than using an HTTP redirection.

And there is also a need for a simple mechanism to work locally on the ‘real’ stuff while the teaser is there :-)