### PR TITLE
Add Piwik analytics tool

### DIFF
--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -7,6 +7,35 @@
     <title>@yield('title', 'Le Val’heureux')</title>
 
     <link rel="stylesheet" href="{{ mix('css/main.css') }}">
+
+    <!--
+        This sends stats to Piwik, an open source and privacy-friendly
+        analytics tool. We configured it to make it respect privacy
+        even more, by honoring ‘Do Not Track’ headers, not using
+        any cookie and not storing full IP addresses, among
+        other things. Privacy is a human right, period!
+    -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      // Do not use cookies.
+      _paq.push(['disableCookies']);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//stats.valheureux.be/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', '1']);
+        var d=document,
+            g=d.createElement('script'),
+            s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript';
+        g.async=true;
+        g.defer=true;
+        g.src=u+'piwik.js';
+        s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+
 </head>
 <body>
     <div class="site-header">

--- a/resources/views/public/launch-teaser.blade.php
+++ b/resources/views/public/launch-teaser.blade.php
@@ -7,6 +7,34 @@
     <title>Le Valeureux devient le Val’heureux</title>
 
     <link rel="stylesheet" href="{{ asset('css/teaser.css') }}">
+
+    <!--
+        This sends stats to Piwik, an open source and privacy-friendly
+        analytics tool. We configured it to make it respect privacy
+        even more, by honoring ‘Do Not Track’ headers, not using
+        any cookie and not storing full IP addresses, among
+        other things. Privacy is a human right, period!
+    -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      // Do not use cookies.
+      _paq.push(['disableCookies']);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//stats.valheureux.be/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', '1']);
+        var d=document,
+            g=d.createElement('script'),
+            s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript';
+        g.async=true;
+        g.defer=true;
+        g.src=u+'piwik.js';
+        s.parentNode.insertBefore(g,s);
+      })();
+    </script>
 </head>
 <body class="launch-teaser">
     <h1>Le Valeureux devient le Val’heureux</h1>


### PR DESCRIPTION
Getting some stats about people visiting the site is useful for many things, including ensuring proper technical support. However, this needs to be done in a way that is privacy-friendly and, even more important, respectful of people.

To this end, we use Piwik, which is probably the only analytics tool that is not thoroughly evil. And we configure Piwik to respect people even more.

Some of this configuration is done server-side on the Piwik install, while other settings are configured on the client. The tracking code we include via this pull request, for example, has been configured to not use any cookie.